### PR TITLE
Revert "Tom components 20221116"

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -944,10 +944,6 @@ export namespace Components {
         "videoUrl": string;
     }
 }
-export interface BiggiveButtonCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLBiggiveButtonElement;
-}
 export interface BiggiveCampaignCardFilterGridCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLBiggiveCampaignCardFilterGridElement;
@@ -1447,7 +1443,6 @@ declare namespace LocalJSX {
           * Text
          */
         "label"?: string;
-        "onDoButtonClick"?: (event: BiggiveButtonCustomEvent<string>) => void;
         /**
           * Rounded corners
          */

--- a/src/components/biggive-button/biggive-button.tsx
+++ b/src/components/biggive-button/biggive-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, Event, EventEmitter, h } from '@stencil/core';
+import { Component, Prop, h } from '@stencil/core';
 
 @Component({
   tag: 'biggive-button',
@@ -6,14 +6,6 @@ import { Component, Prop, Event, EventEmitter, h } from '@stencil/core';
   shadow: true,
 })
 export class BiggiveButton {
-  @Event({
-    eventName: 'doButtonClick',
-    composed: true,
-    cancelable: true,
-    bubbles: true,
-  })
-  doButtonClick: EventEmitter<string>;
-
   /**
    * Space below component
    */
@@ -49,15 +41,11 @@ export class BiggiveButton {
    */
   @Prop() rounded: boolean = false;
 
-  handleButtonClick() {
-    this.doButtonClick.emit(this.url);
-  }
-
   render() {
     return (
       <div class={'container space-below-' + this.spaceBelow}>
         <a href={this.url} class={'button button-' + this.colourScheme + ' full-width-' + this.fullWidth.toString() + ' size-' + this.size + ' rounded-' + this.rounded.toString()}>
-          <span onClick={this.handleButtonClick}>{this.label}</span>
+          {this.label}
         </a>
       </div>
     );

--- a/src/components/biggive-button/test/biggive-button.spec.tsx
+++ b/src/components/biggive-button/test/biggive-button.spec.tsx
@@ -12,7 +12,7 @@ describe('biggive-button', () => {
         <mock:shadow-root>
           <div class="container space-below-1">
             <a class="button button-primary full-width-false rounded-false size-medium" href="https://www.google.com">
-              <span>Donate now</span>
+              Donate now
             </a>
           </div>
         </mock:shadow-root>


### PR DESCRIPTION
Reverts thebiggive/components#54
1. I'm having to revert the PR because it's not needed - we can simply use [routerLink] in Angular to make use of the Angular router for DON-604, so a custom even emit is not needed.
2. It's a breaking change
