### PR TITLE
Revert "DON-667: Declare compatibility with Angular 15 as well as 14 to allow…"

### DIFF
--- a/angular/projects/components/package.json
+++ b/angular/projects/components/package.json
@@ -3,8 +3,8 @@
   "description": "Angular-packaged components for @biggive apps",
   "version": "1.0.183",
   "peerDependencies": {
-    "@angular/common": "^14.1.0|^15.0.4",
-    "@angular/core": "^14.1.0|^15.0.4",
+    "@angular/common": "^14.1.0",
+    "@angular/core": "^14.1.0",
     "@biggive/components": "^1.0"
   },
   "dependencies": {


### PR DESCRIPTION
Reverts thebiggive/components#95

Reason: Angular front-end throws the following error when running `npm update`:
```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "^14.1.0|^15.0.4" of package "@angular/common@^14.1.0|^15.0.4": Tags may not have any characters that encodeURIComponent encodes.
```
