### PR TITLE
COM-28 introduce new biggive-main-menu to replace biggive-header

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -811,6 +811,8 @@ export namespace Components {
          */
         "teaserColour": string;
     }
+    interface BiggiveMainMenu {
+    }
     interface BiggiveMiscIcon {
         /**
           * Background colour
@@ -1244,6 +1246,12 @@ declare global {
         prototype: HTMLBiggiveImageFeatureElement;
         new (): HTMLBiggiveImageFeatureElement;
     };
+    interface HTMLBiggiveMainMenuElement extends Components.BiggiveMainMenu, HTMLStencilElement {
+    }
+    var HTMLBiggiveMainMenuElement: {
+        prototype: HTMLBiggiveMainMenuElement;
+        new (): HTMLBiggiveMainMenuElement;
+    };
     interface HTMLBiggiveMiscIconElement extends Components.BiggiveMiscIcon, HTMLStencilElement {
     }
     var HTMLBiggiveMiscIconElement: {
@@ -1384,6 +1392,7 @@ declare global {
         "biggive-icon-group": HTMLBiggiveIconGroupElement;
         "biggive-image": HTMLBiggiveImageElement;
         "biggive-image-feature": HTMLBiggiveImageFeatureElement;
+        "biggive-main-menu": HTMLBiggiveMainMenuElement;
         "biggive-misc-icon": HTMLBiggiveMiscIconElement;
         "biggive-nav-group": HTMLBiggiveNavGroupElement;
         "biggive-nav-item": HTMLBiggiveNavItemElement;
@@ -2231,6 +2240,8 @@ declare namespace LocalJSX {
          */
         "teaserColour"?: string;
     }
+    interface BiggiveMainMenu {
+    }
     interface BiggiveMiscIcon {
         /**
           * Background colour
@@ -2516,6 +2527,7 @@ declare namespace LocalJSX {
         "biggive-icon-group": BiggiveIconGroup;
         "biggive-image": BiggiveImage;
         "biggive-image-feature": BiggiveImageFeature;
+        "biggive-main-menu": BiggiveMainMenu;
         "biggive-misc-icon": BiggiveMiscIcon;
         "biggive-nav-group": BiggiveNavGroup;
         "biggive-nav-item": BiggiveNavItem;
@@ -2566,6 +2578,7 @@ declare module "@stencil/core" {
             "biggive-icon-group": LocalJSX.BiggiveIconGroup & JSXBase.HTMLAttributes<HTMLBiggiveIconGroupElement>;
             "biggive-image": LocalJSX.BiggiveImage & JSXBase.HTMLAttributes<HTMLBiggiveImageElement>;
             "biggive-image-feature": LocalJSX.BiggiveImageFeature & JSXBase.HTMLAttributes<HTMLBiggiveImageFeatureElement>;
+            "biggive-main-menu": LocalJSX.BiggiveMainMenu & JSXBase.HTMLAttributes<HTMLBiggiveMainMenuElement>;
             "biggive-misc-icon": LocalJSX.BiggiveMiscIcon & JSXBase.HTMLAttributes<HTMLBiggiveMiscIconElement>;
             "biggive-nav-group": LocalJSX.BiggiveNavGroup & JSXBase.HTMLAttributes<HTMLBiggiveNavGroupElement>;
             "biggive-nav-item": LocalJSX.BiggiveNavItem & JSXBase.HTMLAttributes<HTMLBiggiveNavItemElement>;

--- a/src/components/biggive-article-card/readme.md
+++ b/src/components/biggive-article-card/readme.md
@@ -33,7 +33,6 @@
 ```mermaid
 graph TD;
   biggive-article-card --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-article-card fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-basic-card/readme.md
+++ b/src/components/biggive-basic-card/readme.md
@@ -36,7 +36,6 @@
 ```mermaid
 graph TD;
   biggive-basic-card --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-basic-card fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-button/readme.md
+++ b/src/components/biggive-button/readme.md
@@ -7,20 +7,17 @@
 
 ## Properties
 
-| Property           | Attribute            | Description                                                                                                                                                                                             | Type      | Default      |
-| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------ |
-| `centered`         | `centered`           | Centered                                                                                                                                                                                                | `boolean` | `false`      |
-| `colourScheme`     | `colour-scheme`      | Colour Scheme                                                                                                                                                                                           | `string`  | `'primary'`  |
-| `datetime`         | `datetime`           | To be used alongside isFutureCampaign = true or isPastCampaign = true. If either is true, we render out: 'Launches: ' + datetime or 'Closed: ' + datetime. Preferred format: DD/MM/YYYY, HH:MM DON-661. | `string`  | `undefined`  |
-| `fullWidth`        | `full-width`         | Display full width                                                                                                                                                                                      | `boolean` | `false`      |
-| `isFutureCampaign` | `is-future-campaign` | Boolean flag telling the component if the campaign is in the future (not open yet).                                                                                                                     | `boolean` | `false`      |
-| `isPastCampaign`   | `is-past-campaign`   | Boolean flag telling the component if the campaign is in the future (not open yet).                                                                                                                     | `boolean` | `false`      |
-| `label`            | `label`              | Text                                                                                                                                                                                                    | `string`  | `'Click me'` |
-| `openInNewTab`     | `open-in-new-tab`    | New Tab                                                                                                                                                                                                 | `boolean` | `false`      |
-| `rounded`          | `rounded`            | Rounded corners                                                                                                                                                                                         | `boolean` | `false`      |
-| `size`             | `size`               | Size                                                                                                                                                                                                    | `string`  | `'medium'`   |
-| `spaceBelow`       | `space-below`        | Space below component                                                                                                                                                                                   | `number`  | `1`          |
-| `url`              | `url`                | URL                                                                                                                                                                                                     | `string`  | `undefined`  |
+| Property       | Attribute         | Description           | Type      | Default      |
+| -------------- | ----------------- | --------------------- | --------- | ------------ |
+| `centered`     | `centered`        | Centered              | `boolean` | `false`      |
+| `colourScheme` | `colour-scheme`   | Colour Scheme         | `string`  | `'primary'`  |
+| `fullWidth`    | `full-width`      | Display full width    | `boolean` | `false`      |
+| `label`        | `label`           | Text                  | `string`  | `'Click me'` |
+| `openInNewTab` | `open-in-new-tab` | New Tab               | `boolean` | `false`      |
+| `rounded`      | `rounded`         | Rounded corners       | `boolean` | `false`      |
+| `size`         | `size`            | Size                  | `string`  | `'medium'`   |
+| `spaceBelow`   | `space-below`     | Space below component | `number`  | `1`          |
+| `url`          | `url`             | URL                   | `string`  | `undefined`  |
 
 
 ## Events
@@ -45,14 +42,9 @@
  - [biggive-search](../biggive-search)
  - [biggive-video-feature](../biggive-video-feature)
 
-### Depends on
-
-- [biggive-misc-icon](../biggive-misc-icon)
-
 ### Graph
 ```mermaid
 graph TD;
-  biggive-button --> biggive-misc-icon
   biggive-article-card --> biggive-button
   biggive-basic-card --> biggive-button
   biggive-call-to-action --> biggive-button

--- a/src/components/biggive-call-to-action/readme.md
+++ b/src/components/biggive-call-to-action/readme.md
@@ -41,7 +41,6 @@
 ```mermaid
 graph TD;
   biggive-call-to-action --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-call-to-action fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-campaign-card-filter-grid/readme.md
+++ b/src/components/biggive-campaign-card-filter-grid/readme.md
@@ -48,7 +48,6 @@ graph TD;
   biggive-campaign-card-filter-grid --> biggive-form-field-select
   biggive-campaign-card-filter-grid --> biggive-form-field-select-option
   biggive-campaign-card-filter-grid --> biggive-popup
-  biggive-button --> biggive-misc-icon
   style biggive-campaign-card-filter-grid fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-campaign-card/readme.md
+++ b/src/components/biggive-campaign-card/readme.md
@@ -43,14 +43,15 @@ in a secondary column alongside more detail about the same campaign.
 ### Depends on
 
 - [biggive-progress-bar](../biggive-progress-bar)
+- [biggive-misc-icon](../biggive-misc-icon)
 - [biggive-button](../biggive-button)
 
 ### Graph
 ```mermaid
 graph TD;
   biggive-campaign-card --> biggive-progress-bar
+  biggive-campaign-card --> biggive-misc-icon
   biggive-campaign-card --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-campaign-card fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-footer/readme.md
+++ b/src/components/biggive-footer/readme.md
@@ -15,7 +15,6 @@
 ```mermaid
 graph TD;
   biggive-footer --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-footer fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-hero-image/readme.md
+++ b/src/components/biggive-hero-image/readme.md
@@ -37,7 +37,6 @@ Provides a large format image-based header feature, typically used at the top of
 ```mermaid
 graph TD;
   biggive-hero-image --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-hero-image fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-image-feature/readme.md
+++ b/src/components/biggive-image-feature/readme.md
@@ -34,7 +34,6 @@
 ```mermaid
 graph TD;
   biggive-image-feature --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-image-feature fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -324,6 +324,15 @@ nav {
 						}
 					}
 				}
+
+				&:hover {
+					.sub-menu {
+						background-color: inherit !important;
+						.sub-sub-menu {
+							background-color: inherit !important;
+						}
+					}
+				}
 			}
 		}
 	}

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -1,0 +1,308 @@
+:host {
+  display: block;
+}
+
+/* Googlefont Poppins CDN Link */
+// @import "https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700&display=swap";
+* {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+	// font-family: 'Poppins', sans-serif;
+  // @include standard-font();
+  font-family: 'Euclid Triangle', sans-serif;
+}
+.arrow {
+  height: 10px;
+  // width: 22px;
+  margin-left: 5px;
+  line-height: 70px;
+  text-align: center;
+  display: inline-block;
+  color: black;
+  transition: all 0.3s ease;
+}
+// body {
+// 	min-height: 100vh;
+// }
+nav {
+	// position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	height: 70px;
+	background: white;
+	z-index: 99;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 20%);
+	.navbar {
+		height: 100%;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin: auto;
+		padding: 0 50px;
+		.nav-links {
+			line-height: 70px;
+			height: 100%;
+		}
+		.links {
+			display: flex;
+			li {
+				position: relative;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				list-style: none;
+				padding: 0 14px;
+				a {
+					height: 100%;
+					text-decoration: none;
+					white-space: nowrap;
+					color: black;
+					font-size: 15px;
+					font-weight: 500;
+				}
+				// .arrow {
+				// 	height: 100%;
+				// 	// width: 22px;
+        //   margin-left: 5px;
+				// 	line-height: 70px;
+				// 	text-align: center;
+				// 	display: inline-block;
+				// 	color: black;
+				// 	transition: all 0.3s ease;
+				// }
+				.sub-menu {
+					position: absolute;
+					top: 70px;
+					left: 0;
+					line-height: 40px;
+					box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+					border-radius: 0 0 4px 4px;
+					display: none;
+					z-index: 2;
+					background-color: inherit;
+				}
+				&:hover {
+          .sub-menu-arrow {
+            transform: rotate(90deg);
+          }
+					.sub-menu {
+						display: block;
+            background-color: white;
+            .sub-sub-menu {
+              background-color: white;
+            }
+					}
+				}
+			}
+		}
+	}
+}
+.navbar {
+	.logo {
+		min-width: 180px;
+		width: 180px;
+		a {
+			font-size: 30px;
+			color: black;
+			text-decoration: none;
+			font-weight: 600;
+			display: flex;
+		}
+	}
+	.links {
+		li {
+			.sub-menu {
+				li {
+					padding: 0 22px;
+					border-bottom: 1px solid rgba(255,255,255,0.1);
+				}
+				a {
+					color: black;
+					font-size: 15px;
+					font-weight: 500;
+				}
+				.sub-sub-menu {
+					position: absolute;
+					top: 0;
+					left: 100%;
+					border-radius: 0 4px 4px 4px;
+					z-index: 1;
+					display: none;
+				}
+			}
+		}
+	}
+	.nav-links {
+		.sidebar-logo {
+			display: none;
+		}
+	}
+	.bx-menu {
+		display: none;
+	}
+}
+.links {
+	li {
+		.sub-menu {
+			.more {
+				&:hover {
+					.sub-sub-menu {
+						display: block;
+					}
+				}
+			}
+		}
+	}
+}
+.display-sub-menu {
+	display: block !important;
+}
+.transform-90 {
+	transform: rotate(90deg) !important;
+}
+.transform-180 {
+	transform: rotate(180deg) !important;
+}
+@media (max-width: 1200px) {
+	.navbar {
+		.logo {
+			min-width: 120px;
+			width: 120px;
+		}
+		.links {
+			li {
+				.sub-menu {
+					a {
+						font-size: 13px;
+					}
+				}
+			}
+		}
+	}
+	nav {
+		.navbar {
+			.links {
+				li {
+					padding: 0 7px;
+					a {
+						font-size: 13px;
+					}
+				}
+			}
+		}
+	}
+}
+@media (max-width:968px) {
+	.navbar {
+		.bx-menu {
+			display: block;
+			font-size: 25px;
+			color: black;
+		}
+		.nav-links {
+			.sidebar-logo {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				svg {
+					width: 130px;
+				}
+			}
+		}
+		.links {
+			li {
+				.sub-menu {
+					.sub-sub-menu {
+						display: none;
+						position: relative;
+						left: 0;
+						display: none;
+						li {
+							display: flex;
+							align-items: center;
+							justify-content: space-between;
+						}
+					}
+					.more {
+						span {
+							display: flex;
+							align-items: center;
+						}
+					}
+				}
+			}
+		}
+	}
+	nav {
+		.navbar {
+			.nav-links {
+				position: fixed;
+				top: 0;
+				left: -100%;
+				display: block;
+				max-width: 350px;
+				width: 100%;
+				background: rgb(245, 245, 245);
+				line-height: 40px;
+				padding: 20px;
+				box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+				transition: all 0.5s ease;
+				z-index: 1000;
+				overflow-y: scroll;
+			}
+			.links {
+				display: block;
+				margin-top: 20px;
+				li {
+					.arrow {
+						line-height: 40px;
+					}
+					display: block;
+					border-bottom: 1px solid #e6e6e6;
+					.sub-menu {
+						position: relative;
+						top: 0;
+						box-shadow: none;
+						display: none;
+						li {
+							border-bottom: none;
+						}
+					}
+					&:hover {
+						.sub-menu {
+							display: none;
+						}
+					}
+				}
+			}
+		}
+	}
+	.sidebar-logo {
+		i {
+			font-size: 25px;
+			color: black;
+		}
+	}
+	.links {
+		li {
+			.sub-menu {
+				.more {
+					&:hover {
+						.sub-sub-menu {
+							display: none;
+						}
+					}
+				}
+			}
+		}
+	}
+	@media(max-width:370px) {
+			nav .navbar .nav-links{
+        max-width: 100%;
+		  }
+  }
+}

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -62,6 +62,12 @@ nav {
 		.nav-links {
 			line-height: 70px;
 			height: 100%;
+
+			// .bx-x {
+			// 	&:before {
+			// 		content: "\ebe9";
+			// 	}
+			// }
 		}
 
 		.links {
@@ -285,8 +291,12 @@ nav {
 				align-items: center;
 				justify-content: space-between;
 
-				svg {
+				#mobileLogo {
 					width: 130px;
+				}
+
+				#x {
+					margin-right: 15px;
 				}
 			}
 		}

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -382,6 +382,19 @@ nav {
 						.sub-menu {
 							display: none;
 						}
+
+						// For mobile devices, remove the existing `transform: rotate(90deg)` property set on hover.
+						// Technically, it still works but the bad thing is that the `:hover` feature only turns off
+						// on mobile devices when you click off the sub-menu item. This means that when you open the
+						// submenu on a mobile device, the right caret rotates to point down, but when you click on
+						// it again to close it, it remains pointing down, and doesn't un-rotate 90deg. It only does
+						// so when you click completely off that menu item, like when you open another sub-menu. So,
+						// here I removed the `transform: rotate(90deg)` property set on hover for mobile sizes down.
+						// Instead, the rotation is now manually implemented in JavaScript click handlers - see
+						// `componentDidRender()`.
+						.sub-menu-arrow {
+							transform: unset;
+						}
 					}
 				}
 			}

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -1,5 +1,5 @@
 :host {
-  display: block;
+	display: block;
 }
 
 /* Googlefont Poppins CDN Link */
@@ -9,19 +9,33 @@
 	padding: 0;
 	box-sizing: border-box;
 	// font-family: 'Poppins', sans-serif;
-  // @include standard-font();
-  font-family: 'Euclid Triangle', sans-serif;
+	// @include standard-font();
+	font-family: 'Euclid Triangle', sans-serif;
 }
+
 .arrow {
-  height: 10px;
-  // width: 22px;
-  margin-left: 5px;
-  line-height: 70px;
-  text-align: center;
-  display: inline-block;
-  color: black;
-  transition: all 0.3s ease;
+	height: 10px;
+	// width: 22px;
+	margin-left: 5px;
+	line-height: 70px;
+	text-align: center;
+	display: inline-block;
+	color: black;
+	transition: all 0.3s ease;
 }
+
+// a {
+// 	color: $colour-black;
+// 	text-decoration: none;
+// 	display: inline-block;
+// 	&.icon-green {
+// 	  padding-left: 20px;
+// 	  background-image: url(/assets/images/triangles-combined.svg);
+// 	  background-repeat: no-repeat;
+// 	  background-size: auto 10px;
+// 	  background-position: left center;;
+// 	}
+// }
 // body {
 // 	min-height: 100vh;
 // }
@@ -35,6 +49,7 @@ nav {
 	background: white;
 	z-index: 99;
 	box-shadow: 0 1px 2px rgb(0 0 0 / 20%);
+
 	.navbar {
 		height: 100%;
 		width: 100%;
@@ -43,12 +58,15 @@ nav {
 		justify-content: space-between;
 		margin: auto;
 		padding: 0 50px;
+
 		.nav-links {
 			line-height: 70px;
 			height: 100%;
 		}
+
 		.links {
 			display: flex;
+
 			li {
 				position: relative;
 				display: flex;
@@ -56,6 +74,7 @@ nav {
 				justify-content: space-between;
 				list-style: none;
 				padding: 0 14px;
+
 				a {
 					height: 100%;
 					text-decoration: none;
@@ -64,10 +83,11 @@ nav {
 					font-size: 15px;
 					font-weight: 500;
 				}
+
 				// .arrow {
 				// 	height: 100%;
 				// 	// width: 22px;
-        //   margin-left: 5px;
+				//   margin-left: 5px;
 				// 	line-height: 70px;
 				// 	text-align: center;
 				// 	display: inline-block;
@@ -85,26 +105,67 @@ nav {
 					z-index: 2;
 					background-color: inherit;
 				}
+
 				&:hover {
-          .sub-menu-arrow {
-            transform: rotate(90deg);
-          }
+					.sub-menu-arrow {
+						transform: rotate(90deg);
+					}
+
 					.sub-menu {
 						display: block;
-            background-color: white;
-            .sub-sub-menu {
-              background-color: white;
-            }
+						background-color: white;
+
+						.sub-sub-menu {
+							background-color: white;
+
+							a {
+								color: $colour-black;
+								text-decoration: none;
+								display: inline-block;
+
+								// target all classes prefixed with 'icon-' so we don't repeat code
+								&[class^='icon-'], &[class*='icon-'] {
+									padding-left: 20px;
+									background-repeat: no-repeat;
+									background-size: auto 10px;
+									background-position: left center;
+								}
+								&.icon-green {
+								  background-image: url(/assets/images/triangles-combined.svg);
+								}
+								&.icon-children {
+									background-image: url(/assets/images/triangles-combined-children.svg);
+								}
+								&.icon-christmas {
+									background-image: url(/assets/images/triangles-combined-christmas-challenge.svg);
+								}
+								&.icon-green-match {
+									background-image: url(/assets/images/triangles-combined-green-match.svg);
+								}
+								&.icon-women-girls {
+									background-image: url(/assets/images/triangles-combined-women-girls.svg);
+								}
+								&.icon-anchor-match {
+									background-image: url(/assets/images/triangles-combined-anchor.svg);
+								}
+								&.icon-emergency {
+									background-image: url(/assets/images/triangles-combined-emergency.svg);
+								}
+
+							}
+						}
 					}
 				}
 			}
 		}
 	}
 }
+
 .navbar {
 	.logo {
 		min-width: 180px;
 		width: 180px;
+
 		a {
 			font-size: 30px;
 			color: black;
@@ -113,18 +174,21 @@ nav {
 			display: flex;
 		}
 	}
+
 	.links {
 		li {
 			.sub-menu {
 				li {
 					padding: 0 22px;
-					border-bottom: 1px solid rgba(255,255,255,0.1);
+					border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 				}
+
 				a {
 					color: black;
 					font-size: 15px;
 					font-weight: 500;
 				}
+
 				.sub-sub-menu {
 					position: absolute;
 					top: 0;
@@ -136,15 +200,18 @@ nav {
 			}
 		}
 	}
+
 	.nav-links {
 		.sidebar-logo {
 			display: none;
 		}
 	}
+
 	.bx-menu {
 		display: none;
 	}
 }
+
 .links {
 	li {
 		.sub-menu {
@@ -158,21 +225,26 @@ nav {
 		}
 	}
 }
+
 .display-sub-menu {
 	display: block !important;
 }
+
 .transform-90 {
 	transform: rotate(90deg) !important;
 }
+
 .transform-180 {
 	transform: rotate(180deg) !important;
 }
+
 @media (max-width: 1200px) {
 	.navbar {
 		.logo {
 			min-width: 120px;
 			width: 120px;
 		}
+
 		.links {
 			li {
 				.sub-menu {
@@ -183,11 +255,13 @@ nav {
 			}
 		}
 	}
+
 	nav {
 		.navbar {
 			.links {
 				li {
 					padding: 0 7px;
+
 					a {
 						font-size: 13px;
 					}
@@ -196,6 +270,7 @@ nav {
 		}
 	}
 }
+
 @media (max-width:968px) {
 	.navbar {
 		.bx-menu {
@@ -203,16 +278,19 @@ nav {
 			font-size: 25px;
 			color: black;
 		}
+
 		.nav-links {
 			.sidebar-logo {
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
+
 				svg {
 					width: 130px;
 				}
 			}
 		}
+
 		.links {
 			li {
 				.sub-menu {
@@ -221,12 +299,14 @@ nav {
 						position: relative;
 						left: 0;
 						display: none;
+
 						li {
 							display: flex;
 							align-items: center;
 							justify-content: space-between;
 						}
 					}
+
 					.more {
 						span {
 							display: flex;
@@ -237,6 +317,7 @@ nav {
 			}
 		}
 	}
+
 	nav {
 		.navbar {
 			.nav-links {
@@ -254,24 +335,30 @@ nav {
 				z-index: 1000;
 				overflow-y: scroll;
 			}
+
 			.links {
 				display: block;
 				margin-top: 20px;
+
 				li {
 					.arrow {
 						line-height: 40px;
 					}
+
 					display: block;
 					border-bottom: 1px solid #e6e6e6;
+
 					.sub-menu {
 						position: relative;
 						top: 0;
 						box-shadow: none;
 						display: none;
+
 						li {
 							border-bottom: none;
 						}
 					}
+
 					&:hover {
 						.sub-menu {
 							display: none;
@@ -281,12 +368,14 @@ nav {
 			}
 		}
 	}
+
 	.sidebar-logo {
 		i {
 			font-size: 25px;
 			color: black;
 		}
 	}
+
 	.links {
 		li {
 			.sub-menu {
@@ -300,9 +389,10 @@ nav {
 			}
 		}
 	}
+
 	@media(max-width:370px) {
-			nav .navbar .nav-links{
-        max-width: 100%;
-		  }
-  }
+		nav .navbar .nav-links {
+			max-width: 100%;
+		}
+	}
 }

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -24,23 +24,37 @@
 	transition: all 0.3s ease;
 }
 
-// a {
-// 	color: $colour-black;
-// 	text-decoration: none;
-// 	display: inline-block;
-// 	&.icon-green {
-// 	  padding-left: 20px;
-// 	  background-image: url(/assets/images/triangles-combined.svg);
-// 	  background-repeat: no-repeat;
-// 	  background-size: auto 10px;
-// 	  background-position: left center;;
-// 	}
-// }
-// body {
-// 	min-height: 100vh;
-// }
+a {
+	// target all classes prefixed with 'icon-' so we don't repeat code
+	&[class^='icon-'], &[class*='icon-'] {
+		padding-left: 20px;
+		background-repeat: no-repeat;
+		background-size: auto 10px;
+		background-position: left center;
+	}
+	&.icon-green {
+	  background-image: url(/assets/images/triangles-combined.svg);
+	}
+	&.icon-children {
+		background-image: url(/assets/images/triangles-combined-children.svg);
+	}
+	&.icon-christmas {
+		background-image: url(/assets/images/triangles-combined-christmas-challenge.svg);
+	}
+	&.icon-green-match {
+		background-image: url(/assets/images/triangles-combined-green-match.svg);
+	}
+	&.icon-women-girls {
+		background-image: url(/assets/images/triangles-combined-women-girls.svg);
+	}
+	&.icon-anchor-match {
+		background-image: url(/assets/images/triangles-combined-anchor.svg);
+	}
+	&.icon-emergency {
+		background-image: url(/assets/images/triangles-combined-emergency.svg);
+	}
+}
 nav {
-	// position: fixed;
 	top: 0;
 	left: 0;
 	width: 100%;
@@ -89,17 +103,6 @@ nav {
 					font-size: 15px;
 					font-weight: 500;
 				}
-
-				// .arrow {
-				// 	height: 100%;
-				// 	// width: 22px;
-				//   margin-left: 5px;
-				// 	line-height: 70px;
-				// 	text-align: center;
-				// 	display: inline-block;
-				// 	color: black;
-				// 	transition: all 0.3s ease;
-				// }
 				.sub-menu {
 					position: absolute;
 					top: 70px;
@@ -123,42 +126,6 @@ nav {
 
 						.sub-sub-menu {
 							background-color: white;
-
-							a {
-								color: $colour-black;
-								text-decoration: none;
-								display: inline-block;
-
-								// target all classes prefixed with 'icon-' so we don't repeat code
-								&[class^='icon-'], &[class*='icon-'] {
-									padding-left: 20px;
-									background-repeat: no-repeat;
-									background-size: auto 10px;
-									background-position: left center;
-								}
-								&.icon-green {
-								  background-image: url(/assets/images/triangles-combined.svg);
-								}
-								&.icon-children {
-									background-image: url(/assets/images/triangles-combined-children.svg);
-								}
-								&.icon-christmas {
-									background-image: url(/assets/images/triangles-combined-christmas-challenge.svg);
-								}
-								&.icon-green-match {
-									background-image: url(/assets/images/triangles-combined-green-match.svg);
-								}
-								&.icon-women-girls {
-									background-image: url(/assets/images/triangles-combined-women-girls.svg);
-								}
-								&.icon-anchor-match {
-									background-image: url(/assets/images/triangles-combined-anchor.svg);
-								}
-								&.icon-emergency {
-									background-image: url(/assets/images/triangles-combined-emergency.svg);
-								}
-
-							}
 						}
 					}
 				}

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -1,6 +1,6 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Element, Host, h } from '@stencil/core';
 import { faCaretRight } from '@fortawesome/pro-duotone-svg-icons';
-import { faBars } from '@fortawesome/pro-solid-svg-icons';
+import { faBars, faX } from '@fortawesome/pro-solid-svg-icons';
 
 @Component({
   tag: 'biggive-main-menu',
@@ -8,6 +8,15 @@ import { faBars } from '@fortawesome/pro-solid-svg-icons';
   shadow: true,
 })
 export class BiggiveMainMenu {
+  @Element() host: HTMLBiggiveHeaderElement;
+  openMobileMenu = () => {
+    const mobileMenu = this.host.shadowRoot.querySelector('.nav-links') as HTMLElement;
+    mobileMenu.style.left = '0';
+  };
+  closeMobileMenu = () => {
+    const mobileMenu = this.host.shadowRoot.querySelector('.nav-links') as HTMLElement;
+    mobileMenu.style.left = '-100%';
+  };
   render() {
     return (
       <Host>
@@ -15,7 +24,14 @@ export class BiggiveMainMenu {
           <div class="navbar">
             {/* <i class="bx bx-menu"></i> */}
             {/* <i class="bx bx-menu nav-toggle"></i> */}
-            <svg class="bx bx-menu fill-black" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox={'0 0 ' + faBars.icon[0] + ' ' + faBars.icon[1]}>
+            <svg
+              class="bx bx-menu fill-black"
+              width="20"
+              height="20"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox={'0 0 ' + faBars.icon[0] + ' ' + faBars.icon[1]}
+              onClick={this.openMobileMenu}
+            >
               <path d={faBars.icon[4].toString()} />
             </svg>
 
@@ -29,11 +45,22 @@ export class BiggiveMainMenu {
             </div>
             <div class="nav-links">
               <div class="sidebar-logo">
-                <svg version="1.1" x="0px" y="0px" viewBox="0 0 140.9 30">
+                <svg version="1.1" x="0px" y="0px" viewBox="0 0 140.9 30" id="mobileLogo">
                   <path d="M51.9,6.1c-1.7,0-3.1-1.4-3.1-3s1.4-3,3.1-3C53.6,0,55,1.4,55,3S53.6,6.1,51.9,6.1z M49.3,23.8h5V7.7h-5V23.8z M68.5,7.7v1 c-0.8-0.7-2.3-1.4-4.1-1.4c-4.5,0-8.2,3.2-8.2,7.9c0,4.7,3.7,7.9,8.2,7.9c1.8,0,3.4-0.5,4.1-1.4v0.9c0,2.1-1.9,3.1-4.4,3.1 c-2.2,0-4-0.5-5.8-1.4V29c2.1,0.7,4.4,1,6,1c5,0,9.2-2,9.2-7.3v-15L68.5,7.7L68.5,7.7z M68.5,17.2c-0.7,1-1.9,1.4-3.2,1.4 c-2.1,0-3.8-1.2-3.8-3.4c0-2.2,1.7-3.4,3.8-3.4c1.3,0,2.5,0.6,3.2,1.5V17.2z M88.1,24.2c4,0,6.4-0.7,8.5-2V10h-11v4.7h5.8v4.1 c-0.8,0.2-1.8,0.4-3.2,0.4c-4.9,0-7.3-3.2-7.3-6.8c0-3.7,2.8-6.8,8-6.8c2.2,0,4.3,0.6,5.8,1.4V1.7c-1.5-0.6-3.4-1.1-6.1-1.1 c-7.6,0-13,5.3-13,11.8C75.5,19.1,80.4,24.2,88.1,24.2z M101.4,6.1c-1.7,0-3.1-1.4-3.1-3s1.4-3,3.1-3c1.8,0,3.2,1.4,3.2,3 S103.1,6.1,101.4,6.1z M98.8,23.8h5V7.7h-5V23.8z M115.1,15l-4.3-7.2H105l10.1,16.4l10.1-16.4h-5.8L115.1,15z M129.3,16.9h11.6 c0.1-7-4.2-9.5-8.4-9.5c-4.5,0-8.5,2.6-8.6,8.4c0,5.6,4.1,8.4,9.1,8.4c2.2,0,4.4-0.3,6.4-1.3v-4.4c-2.5,1.4-4.1,1.4-5.6,1.4 C131.7,19.8,129.5,19.2,129.3,16.9z M132.5,11.1c1.5,0,2.8,0.7,3,2.7h-6.2C129.6,11.9,131,11.1,132.5,11.1z M43.5,11.4 c1.2-1,1.8-2.4,1.8-4c0-3.1-3-6.3-7.3-6.3h-8v22.8h10.4c4.1,0,7.2-3,7.2-6.8C47.5,14.8,46.5,12.3,43.5,11.4z M35.2,5.7h2.4 C39,5.7,40,6.8,40,8c0,1.2-1,2.2-2.5,2.2h-2.4V5.7z M39.9,19.2h-4.7v-4.6h4.7c1.4,0,2.5,1,2.5,2.3C42.4,18.1,41.3,19.2,39.9,19.2z" />
                   <path d="M13.5,1l13.5,23H0L13.5,1z" />
                 </svg>
-                <i class="bx bx-x"></i>
+                {/* <i class="bx bx-x"></i> */}
+                <svg
+                  class="bx bx-x fill-black"
+                  id="x"
+                  width="10"
+                  height="10"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox={'0 0 ' + faX.icon[0] + ' ' + faX.icon[1]}
+                  onClick={this.closeMobileMenu}
+                >
+                  <path d={faX.icon[4].toString()} />
+                </svg>
               </div>
               <ul class="links">
                 <li>

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -77,19 +77,29 @@ export class BiggiveMainMenu {
                       </span>
                       <ul class="sub-sub-menu">
                         <li>
-                          <a href="#">Christmas Challenge</a>
+                          <a href="#" class="icon-green">
+                            Christmas Challenge
+                          </a>
                         </li>
                         <li>
-                          <a href="#">Champions for Children</a>
+                          <a href="#" class="icon-children">
+                            Champions for Children
+                          </a>
                         </li>
                         <li>
-                          <a href="#">Green Match Fund</a>
+                          <a href="#" class="icon-green-match">
+                            Green Match Fund
+                          </a>
                         </li>
                         <li>
-                          <a href="#">Women & Girls Match Fund</a>
+                          <a href="#" class="icon-women-girls">
+                            Women & Girls Match Fund
+                          </a>
                         </li>
                         <li>
-                          <a href="#">Emergency Match Fund</a>
+                          <a href="#" class="icon-emergency">
+                            Emergency Match Fund
+                          </a>
                         </li>
                       </ul>
                     </li>

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -1,0 +1,171 @@
+import { Component, Host, h } from '@stencil/core';
+import { faCaretRight } from '@fortawesome/pro-duotone-svg-icons';
+import { faBars } from '@fortawesome/pro-solid-svg-icons';
+
+@Component({
+  tag: 'biggive-main-menu',
+  styleUrl: 'biggive-main-menu.scss',
+  shadow: true,
+})
+export class BiggiveMainMenu {
+  render() {
+    return (
+      <Host>
+        <nav>
+          <div class="navbar">
+            {/* <i class="bx bx-menu"></i> */}
+            {/* <i class="bx bx-menu nav-toggle"></i> */}
+            <svg class="bx bx-menu fill-black" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox={'0 0 ' + faBars.icon[0] + ' ' + faBars.icon[1]}>
+              <path d={faBars.icon[4].toString()} />
+            </svg>
+
+            <div class="logo">
+              <a href="#">
+                <svg version="1.1" x="0px" y="0px" viewBox="0 0 140.9 30">
+                  <path d="M51.9,6.1c-1.7,0-3.1-1.4-3.1-3s1.4-3,3.1-3C53.6,0,55,1.4,55,3S53.6,6.1,51.9,6.1z M49.3,23.8h5V7.7h-5V23.8z M68.5,7.7v1 c-0.8-0.7-2.3-1.4-4.1-1.4c-4.5,0-8.2,3.2-8.2,7.9c0,4.7,3.7,7.9,8.2,7.9c1.8,0,3.4-0.5,4.1-1.4v0.9c0,2.1-1.9,3.1-4.4,3.1 c-2.2,0-4-0.5-5.8-1.4V29c2.1,0.7,4.4,1,6,1c5,0,9.2-2,9.2-7.3v-15L68.5,7.7L68.5,7.7z M68.5,17.2c-0.7,1-1.9,1.4-3.2,1.4 c-2.1,0-3.8-1.2-3.8-3.4c0-2.2,1.7-3.4,3.8-3.4c1.3,0,2.5,0.6,3.2,1.5V17.2z M88.1,24.2c4,0,6.4-0.7,8.5-2V10h-11v4.7h5.8v4.1 c-0.8,0.2-1.8,0.4-3.2,0.4c-4.9,0-7.3-3.2-7.3-6.8c0-3.7,2.8-6.8,8-6.8c2.2,0,4.3,0.6,5.8,1.4V1.7c-1.5-0.6-3.4-1.1-6.1-1.1 c-7.6,0-13,5.3-13,11.8C75.5,19.1,80.4,24.2,88.1,24.2z M101.4,6.1c-1.7,0-3.1-1.4-3.1-3s1.4-3,3.1-3c1.8,0,3.2,1.4,3.2,3 S103.1,6.1,101.4,6.1z M98.8,23.8h5V7.7h-5V23.8z M115.1,15l-4.3-7.2H105l10.1,16.4l10.1-16.4h-5.8L115.1,15z M129.3,16.9h11.6 c0.1-7-4.2-9.5-8.4-9.5c-4.5,0-8.5,2.6-8.6,8.4c0,5.6,4.1,8.4,9.1,8.4c2.2,0,4.4-0.3,6.4-1.3v-4.4c-2.5,1.4-4.1,1.4-5.6,1.4 C131.7,19.8,129.5,19.2,129.3,16.9z M132.5,11.1c1.5,0,2.8,0.7,3,2.7h-6.2C129.6,11.9,131,11.1,132.5,11.1z M43.5,11.4 c1.2-1,1.8-2.4,1.8-4c0-3.1-3-6.3-7.3-6.3h-8v22.8h10.4c4.1,0,7.2-3,7.2-6.8C47.5,14.8,46.5,12.3,43.5,11.4z M35.2,5.7h2.4 C39,5.7,40,6.8,40,8c0,1.2-1,2.2-2.5,2.2h-2.4V5.7z M39.9,19.2h-4.7v-4.6h4.7c1.4,0,2.5,1,2.5,2.3C42.4,18.1,41.3,19.2,39.9,19.2z" />
+                  <path d="M13.5,1l13.5,23H0L13.5,1z" />
+                </svg>
+              </a>
+            </div>
+            <div class="nav-links">
+              <div class="sidebar-logo">
+                <svg version="1.1" x="0px" y="0px" viewBox="0 0 140.9 30">
+                  <path d="M51.9,6.1c-1.7,0-3.1-1.4-3.1-3s1.4-3,3.1-3C53.6,0,55,1.4,55,3S53.6,6.1,51.9,6.1z M49.3,23.8h5V7.7h-5V23.8z M68.5,7.7v1 c-0.8-0.7-2.3-1.4-4.1-1.4c-4.5,0-8.2,3.2-8.2,7.9c0,4.7,3.7,7.9,8.2,7.9c1.8,0,3.4-0.5,4.1-1.4v0.9c0,2.1-1.9,3.1-4.4,3.1 c-2.2,0-4-0.5-5.8-1.4V29c2.1,0.7,4.4,1,6,1c5,0,9.2-2,9.2-7.3v-15L68.5,7.7L68.5,7.7z M68.5,17.2c-0.7,1-1.9,1.4-3.2,1.4 c-2.1,0-3.8-1.2-3.8-3.4c0-2.2,1.7-3.4,3.8-3.4c1.3,0,2.5,0.6,3.2,1.5V17.2z M88.1,24.2c4,0,6.4-0.7,8.5-2V10h-11v4.7h5.8v4.1 c-0.8,0.2-1.8,0.4-3.2,0.4c-4.9,0-7.3-3.2-7.3-6.8c0-3.7,2.8-6.8,8-6.8c2.2,0,4.3,0.6,5.8,1.4V1.7c-1.5-0.6-3.4-1.1-6.1-1.1 c-7.6,0-13,5.3-13,11.8C75.5,19.1,80.4,24.2,88.1,24.2z M101.4,6.1c-1.7,0-3.1-1.4-3.1-3s1.4-3,3.1-3c1.8,0,3.2,1.4,3.2,3 S103.1,6.1,101.4,6.1z M98.8,23.8h5V7.7h-5V23.8z M115.1,15l-4.3-7.2H105l10.1,16.4l10.1-16.4h-5.8L115.1,15z M129.3,16.9h11.6 c0.1-7-4.2-9.5-8.4-9.5c-4.5,0-8.5,2.6-8.6,8.4c0,5.6,4.1,8.4,9.1,8.4c2.2,0,4.4-0.3,6.4-1.3v-4.4c-2.5,1.4-4.1,1.4-5.6,1.4 C131.7,19.8,129.5,19.2,129.3,16.9z M132.5,11.1c1.5,0,2.8,0.7,3,2.7h-6.2C129.6,11.9,131,11.1,132.5,11.1z M43.5,11.4 c1.2-1,1.8-2.4,1.8-4c0-3.1-3-6.3-7.3-6.3h-8v22.8h10.4c4.1,0,7.2-3,7.2-6.8C47.5,14.8,46.5,12.3,43.5,11.4z M35.2,5.7h2.4 C39,5.7,40,6.8,40,8c0,1.2-1,2.2-2.5,2.2h-2.4V5.7z M39.9,19.2h-4.7v-4.6h4.7c1.4,0,2.5,1,2.5,2.3C42.4,18.1,41.3,19.2,39.9,19.2z" />
+                  <path d="M13.5,1l13.5,23H0L13.5,1z" />
+                </svg>
+                <i class="bx bx-x"></i>
+              </div>
+              <ul class="links">
+                <li>
+                  <a href="#">Explore Campaigns</a>
+                </li>
+                <li>
+                  <a href="#">For Charities</a>
+                </li>
+                <li>
+                  <a href="#">Funders</a>
+                </li>
+                <li>
+                  <a href="#">Match Funding</a>
+                  {/* <i class="bx bxs-chevron-down sub-menu-arrow arrow  "></i> */}
+                  <svg
+                    class="sub-menu-arrow arrow fill-black"
+                    width="10"
+                    height="10"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox={'0 0 ' + faCaretRight.icon[0] + ' ' + faCaretRight.icon[1]}
+                  >
+                    <path d={faCaretRight.icon[4].toString()} />
+                  </svg>
+                  <ul class="sub-menu">
+                    <li>
+                      <a href="#">Match Funding Explained</a>
+                    </li>
+                    <li class="more">
+                      <span>
+                        <a href="#">Match Funding Opportunities</a>
+                        {/* <i class="bx bxs-chevron-right arrow sub-sub-menu-arrow"></i> */}
+                        <svg
+                          class="sub-sub-menu-arrow arrow fill-black"
+                          width="10"
+                          height="10"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox={'0 0 ' + faCaretRight.icon[0] + ' ' + faCaretRight.icon[1]}
+                        >
+                          <path d={faCaretRight.icon[4].toString()} />
+                        </svg>
+                      </span>
+                      <ul class="sub-sub-menu">
+                        <li>
+                          <a href="#">Christmas Challenge</a>
+                        </li>
+                        <li>
+                          <a href="#">Champions for Children</a>
+                        </li>
+                        <li>
+                          <a href="#">Green Match Fund</a>
+                        </li>
+                        <li>
+                          <a href="#">Women & Girls Match Fund</a>
+                        </li>
+                        <li>
+                          <a href="#">Emergency Match Fund</a>
+                        </li>
+                      </ul>
+                    </li>
+                    <li>
+                      <a href="#">Run your match funding campaign</a>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="#">About us</a>
+                  {/* <i class="bx bxs-chevron-down sub-menu-arrow arrow "></i> */}
+                  <svg
+                    class="sub-menu-arrow arrow fill-black"
+                    width="10"
+                    height="10"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox={'0 0 ' + faCaretRight.icon[0] + ' ' + faCaretRight.icon[1]}
+                  >
+                    <path d={faCaretRight.icon[4].toString()} />
+                  </svg>
+                  <ul class="sub-menu">
+                    <li>
+                      <a href="#">Our Story</a>
+                    </li>
+                    <li>
+                      <a href="#">Our People</a>
+                    </li>
+                    <li>
+                      <a href="#">Our Community</a>
+                    </li>
+                    <li>
+                      <a href="#">Our Fees</a>
+                    </li>
+                    <li>
+                      <a href="#">FAQs</a>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="#">Resources</a>
+                  {/* <i class="bx bxs-chevron-down sub-menu-arrow arrow "></i> */}
+                  <svg
+                    class="sub-menu-arrow arrow fill-black"
+                    width="10"
+                    height="10"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox={'0 0 ' + faCaretRight.icon[0] + ' ' + faCaretRight.icon[1]}
+                  >
+                    <path d={faCaretRight.icon[4].toString()} />
+                  </svg>
+                  <ul class="sub-menu">
+                    <li>
+                      <a href="#">Case Studies</a>
+                    </li>
+                    <li>
+                      <a href="#">Webinars</a>
+                    </li>
+                    <li>
+                      <a href="#">Blog</a>
+                    </li>
+                    <li>
+                      <a href="#">Reports & Insights</a>
+                    </li>
+                    <li>
+                      <a href="#">Press</a>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="#">Charity Login</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </nav>
+      </Host>
+    );
+  }
+}

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -17,6 +17,29 @@ export class BiggiveMainMenu {
     const mobileMenu = this.host.shadowRoot.querySelector('.nav-links') as HTMLElement;
     mobileMenu.style.left = '-100%';
   };
+
+  componentDidRender() {
+    // Sidebar submenu open close js code for mobile menu
+    const subMenuArrows = this.host.shadowRoot.querySelectorAll('.sub-menu-arrow') as NodeListOf<HTMLElement>;
+    subMenuArrows.forEach(subMenuArrow => {
+      subMenuArrow.onclick = () => {
+        subMenuArrow.classList.toggle('transform-180');
+        const subMenu = subMenuArrow.parentNode.querySelector('.sub-menu');
+        subMenu.classList.toggle('display-sub-menu');
+      };
+    });
+
+    // Sidebar sub-sub-menu open close js code for mobile menu
+    const subSubMenuArrows = this.host.shadowRoot.querySelectorAll('.sub-sub-menu-arrow') as NodeListOf<HTMLElement>;
+    subSubMenuArrows.forEach(subSubMenuArrow => {
+      subSubMenuArrow.onclick = () => {
+        subSubMenuArrow.classList.toggle('transform-90');
+        const subSubMenu = subSubMenuArrow.parentNode.parentNode.querySelector('.sub-sub-menu');
+        subSubMenu.classList.toggle('display-sub-menu');
+      };
+    });
+  }
+
   render() {
     return (
       <Host>

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -23,7 +23,8 @@ export class BiggiveMainMenu {
     const subMenuArrows = this.host.shadowRoot.querySelectorAll('.sub-menu-arrow') as NodeListOf<HTMLElement>;
     subMenuArrows.forEach(subMenuArrow => {
       subMenuArrow.onclick = () => {
-        subMenuArrow.classList.toggle('transform-180');
+        subMenuArrow.classList.toggle('transform-90');
+        // subMenu is a sibling node
         const subMenu = subMenuArrow.parentNode.querySelector('.sub-menu');
         subMenu.classList.toggle('display-sub-menu');
       };
@@ -34,6 +35,7 @@ export class BiggiveMainMenu {
     subSubMenuArrows.forEach(subSubMenuArrow => {
       subSubMenuArrow.onclick = () => {
         subSubMenuArrow.classList.toggle('transform-90');
+        // two parents up, not one like above. subSubMenu is actually a sibling to the parent node
         const subSubMenu = subSubMenuArrow.parentNode.parentNode.querySelector('.sub-sub-menu');
         subSubMenu.classList.toggle('display-sub-menu');
       };

--- a/src/components/biggive-main-menu/readme.md
+++ b/src/components/biggive-main-menu/readme.md
@@ -1,0 +1,10 @@
+# biggive-main-menu
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/biggive-main-menu/test/biggive-main-menu.e2e.ts
+++ b/src/components/biggive-main-menu/test/biggive-main-menu.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('biggive-main-menu', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<biggive-main-menu></biggive-main-menu>');
+
+    const element = await page.find('biggive-main-menu');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/biggive-main-menu/test/biggive-main-menu.spec.tsx
+++ b/src/components/biggive-main-menu/test/biggive-main-menu.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { BiggiveMainMenu } from '../biggive-main-menu';
+
+describe('biggive-main-menu', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [BiggiveMainMenu],
+      html: `<biggive-main-menu></biggive-main-menu>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <biggive-main-menu>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </biggive-main-menu>
+    `);
+  });
+});

--- a/src/components/biggive-misc-icon/readme.md
+++ b/src/components/biggive-misc-icon/readme.md
@@ -19,13 +19,13 @@
 
 ### Used by
 
- - [biggive-button](../biggive-button)
+ - [biggive-campaign-card](../biggive-campaign-card)
  - [biggive-campaign-highlights](../biggive-campaign-highlights)
 
 ### Graph
 ```mermaid
 graph TD;
-  biggive-button --> biggive-misc-icon
+  biggive-campaign-card --> biggive-misc-icon
   biggive-campaign-highlights --> biggive-misc-icon
   style biggive-misc-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/biggive-search/readme.md
+++ b/src/components/biggive-search/readme.md
@@ -62,7 +62,6 @@ the parent component).
 ```mermaid
 graph TD;
   biggive-search --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-search fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/biggive-video-feature/readme.md
+++ b/src/components/biggive-video-feature/readme.md
@@ -34,7 +34,6 @@
 ```mermaid
 graph TD;
   biggive-video-feature --> biggive-button
-  biggive-button --> biggive-misc-icon
   style biggive-video-feature fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,8 @@
     </style>
   </head>
   <body>
-    <biggive-header>
+    <biggive-main-menu></biggive-main-menu>
+    <!-- <biggive-header>
       <div slot="social-icons">
         <biggive-social-icon service="Facebook" url="https://www.facebook.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
         <biggive-social-icon service="Twitter" url="https://www.twitter.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
@@ -47,7 +48,7 @@
         <li><a href="#">Contact us</a></li>
         <li><a href="#">Charity login</a></li>
       </ul>
-    </biggive-header>
+    </biggive-header> -->
 
 
     <biggive-totalizer


### PR DESCRIPTION
Currently `biggive-header` has a few issues:

1. No real support for sub-sub-menus, i.e. sub-menus two levels deep
2. Mobile menu doesn't scroll properly
3. The whole website scrolls down when you try to scroll down the menu
4. Big blue call-to-action buttons in mobile version of the header cover much of the menu, especially when sub-menus are expanded
5. No caret icons to show the certain menu items are expandable
6. Clicking on a sub-menu item opens the sub-menu, but re-clicking the same sub-menu item does not close the sub-menu - you have to click elsewhere.

This will all be fixed as part of a new `biggive-main-menu` component.