### PR TITLE
DON-649: Accept heading level as prop passed in to BigGiveBasicCard

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -91,6 +91,7 @@ export namespace Components {
           * Clip top right corner
          */
         "clipTopRightCorner": boolean;
+        "headingLevel": 1 | 2 | 3 | 4 | 5 | 6;
         /**
           * Icon
          */
@@ -1501,6 +1502,7 @@ declare namespace LocalJSX {
           * Clip top right corner
          */
         "clipTopRightCorner"?: boolean;
+        "headingLevel"?: 1 | 2 | 3 | 4 | 5 | 6;
         /**
           * Icon
          */

--- a/src/components/biggive-basic-card/biggive-basic-card.scss
+++ b/src/components/biggive-basic-card/biggive-basic-card.scss
@@ -31,14 +31,15 @@
       @include corner-clip-medium-bottom-left-top-right();
     }
   }
-  
+
   .icon {
     svg {
       width: 50px;
       height: auto;
     }
   }
-  h3 {
+  .title {
+    // these have to be the heading level passed in based on order of headings, but in terms of design we want it look like H3.
     @include heading-3();
     margin-bottom: $spacer-3;
   }

--- a/src/components/biggive-basic-card/biggive-basic-card.tsx
+++ b/src/components/biggive-basic-card/biggive-basic-card.tsx
@@ -76,7 +76,11 @@ export class BiggiveBasicCard {
    */
   @Prop() clipTopRightCorner: boolean = true;
 
+  @Prop() headingLevel: 1 | 2 | 3 | 4 | 5 | 6 = 3;
+
   render() {
+    const HeadingTag = `h${this.headingLevel}`;
+
     return (
       <div
         class={
@@ -101,7 +105,7 @@ export class BiggiveBasicCard {
                 </svg>
               </div>
             ) : null}
-            <h3 class="title">{this.mainTitle}</h3>
+            <HeadingTag class="title">{this.mainTitle}</HeadingTag>
             <div class="subtitle">{this.subtitle}</div>
             <div class="teaser">{this.teaser}</div>
             {this.buttonLabel != null && this.buttonUrl != null && this.buttonUrl != '' ? (

--- a/src/components/biggive-basic-card/readme.md
+++ b/src/components/biggive-basic-card/readme.md
@@ -7,23 +7,24 @@
 
 ## Properties
 
-| Property               | Attribute                 | Description                       | Type      | Default           |
-| ---------------------- | ------------------------- | --------------------------------- | --------- | ----------------- |
-| `backgroundColour`     | `background-colour`       | Background colour.                | `string`  | `'primary'`       |
-| `backgroundImageUrl`   | `background-image-url`    | Full URL of the background image. | `string`  | `''`              |
-| `buttonColourScheme`   | `button-colour-scheme`    | Button Colour Scheme              | `string`  | `'clear-primary'` |
-| `buttonLabel`          | `button-label`            | Button label                      | `string`  | `undefined`       |
-| `buttonUrl`            | `button-url`              | Button URL                        | `string`  | `undefined`       |
-| `cardColour`           | `card-colour`             | Card colour                       | `string`  | `'white'`         |
-| `clipBottomLeftCorner` | `clip-bottom-left-corner` | Clip bottom left corner           | `boolean` | `true`            |
-| `clipTopRightCorner`   | `clip-top-right-corner`   | Clip top right corner             | `boolean` | `true`            |
-| `icon`                 | `icon`                    | Icon                              | `boolean` | `true`            |
-| `iconColour`           | `icon-colour`             | Icon colour                       | `string`  | `'primary'`       |
-| `mainTitle`            | `main-title`              | Main title                        | `string`  | `undefined`       |
-| `spaceBelow`           | `space-below`             | Space below component             | `number`  | `0`               |
-| `subtitle`             | `subtitle`                | Subtitle title                    | `string`  | `undefined`       |
-| `teaser`               | `teaser`                  | Teaser                            | `string`  | `undefined`       |
-| `textColour`           | `text-colour`             | Text colour                       | `string`  | `'black'`         |
+| Property               | Attribute                 | Description                       | Type                         | Default           |
+| ---------------------- | ------------------------- | --------------------------------- | ---------------------------- | ----------------- |
+| `backgroundColour`     | `background-colour`       | Background colour.                | `string`                     | `'primary'`       |
+| `backgroundImageUrl`   | `background-image-url`    | Full URL of the background image. | `string`                     | `''`              |
+| `buttonColourScheme`   | `button-colour-scheme`    | Button Colour Scheme              | `string`                     | `'clear-primary'` |
+| `buttonLabel`          | `button-label`            | Button label                      | `string`                     | `undefined`       |
+| `buttonUrl`            | `button-url`              | Button URL                        | `string`                     | `undefined`       |
+| `cardColour`           | `card-colour`             | Card colour                       | `string`                     | `'white'`         |
+| `clipBottomLeftCorner` | `clip-bottom-left-corner` | Clip bottom left corner           | `boolean`                    | `true`            |
+| `clipTopRightCorner`   | `clip-top-right-corner`   | Clip top right corner             | `boolean`                    | `true`            |
+| `headingLevel`         | `heading-level`           |                                   | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | `3`               |
+| `icon`                 | `icon`                    | Icon                              | `boolean`                    | `true`            |
+| `iconColour`           | `icon-colour`             | Icon colour                       | `string`                     | `'primary'`       |
+| `mainTitle`            | `main-title`              | Main title                        | `string`                     | `undefined`       |
+| `spaceBelow`           | `space-below`             | Space below component             | `number`                     | `0`               |
+| `subtitle`             | `subtitle`                | Subtitle title                    | `string`                     | `undefined`       |
+| `teaser`               | `teaser`                  | Teaser                            | `string`                     | `undefined`       |
+| `textColour`           | `text-colour`             | Text colour                       | `string`                     | `'black'`         |
 
 
 ## Dependencies


### PR DESCRIPTION
The card doesn't know the context so can't properly decide for itself what heading level to live at.