### PR TITLE
Com 14 auto versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,14 +166,12 @@ workflows:
             - jira/notify:
                 job_type: deployment
                 environment_type: staging
-      # *Tag* pushes to `main` (the same conditions for a new version `npm` publish)
-      # deploy a new Storybook Production build.
+      # Pushes to `main`deploy a new Storybook Production build.
       - deploy-production-storybook:
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - main
           context:
             - docker-hub-creds
             - ecs-deploys # Includes S3 stuff used by Donate frontend.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,8 +165,6 @@ workflows:
                 job_type: build
                 environment_type: development
   publish_auto_versioning:
-    depends:
-      - build
     jobs:
       - publish_auto_versioning:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
             --acl public-read \
             --cache-control "max-age=3600"
   publish_auto_versioning:
-    publish:
       <<: *defaults
       steps:
         - checkout
@@ -122,7 +121,6 @@ jobs:
 #            name: Publish Angular components to npm
 #            command: cd angular/dist/components && npm publish --access=public
 
-    <<: *defaults
   # Publishes `@biggive/components` *and* `@biggive/components-angular` (building both on the fly).
   publish:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,39 @@ jobs:
           arguments: |
             --acl public-read \
             --cache-control "max-age=3600"
+  publish_auto_versioning:
+    publish:
+      <<: *defaults
+      steps:
+        - checkout
+        - restore_cache:
+            keys:
+              - v1-dependencies-{{ checksum "package-lock.json" }}
+        - run: npm install
+        - save_cache:
+            paths:
+              - node_modules
+            key: v1-dependencies-{{ checksum "package-lock.json" }}
+        - run: npm run build
+        - run: ./scripts/create-version.sh
+        - run:
+            name: Authenticate with registry
+            command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/.npmrc
+#        - run:
+#            name: Publish core components to npm
+#            command: npm publish --access=public
+#        - run: cd angular && npm install
+#        - run:
+#            name: Build Angular components
+#            command: cd angular && npm run build
+#        - run:
+#            name: Authenticate with registry in Angular components output directory
+#            command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/angular/dist/components/.npmrc
+#        - run:
+#            name: Publish Angular components to npm
+#            command: cd angular/dist/components && npm publish --access=public
 
+    <<: *defaults
   # Publishes `@biggive/components` *and* `@biggive/components-angular` (building both on the fly).
   publish:
     <<: *defaults
@@ -134,6 +166,16 @@ workflows:
             - jira/notify:
                 job_type: build
                 environment_type: development
+  publish_auto_versioning:
+    jobs:
+      - publish_auto_versioning:
+          filters:
+            branches:
+              only: COM-14-auto-versioning
+          context:
+            - docker-hub-creds
+            - jira
+            - npm-publish
   publish:
     jobs:
       - publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,9 +164,9 @@ workflows:
             - jira/notify:
                 job_type: build
                 environment_type: development
-  publish_auto_versioning:
-    jobs:
       - publish_auto_versioning:
+          requires:
+            - build
           filters:
             branches:
               only: COM-14-auto-versioning

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,19 +107,19 @@ jobs:
         - run:
             name: Authenticate with registry
             command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/.npmrc
-#        - run:
-#            name: Publish core components to npm
-#            command: npm publish --access=public
-#        - run: cd angular && npm install
-#        - run:
-#            name: Build Angular components
-#            command: cd angular && npm run build
-#        - run:
-#            name: Authenticate with registry in Angular components output directory
-#            command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/angular/dist/components/.npmrc
-#        - run:
-#            name: Publish Angular components to npm
-#            command: cd angular/dist/components && npm publish --access=public
+        - run:
+            name: Publish core components to npm
+            command: npm publish --access=public .
+        - run: cd angular && npm install
+        - run:
+            name: Build Angular components
+            command: cd angular && npm run build
+        - run:
+            name: Authenticate with registry in Angular components output directory
+            command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/angular/dist/components/.npmrc
+        - run:
+            name: Publish Angular components to npm
+            command: cd angular/dist/components && npm publish --access=public .
 
   # Publishes `@biggive/components` *and* `@biggive/components-angular` (building both on the fly).
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,8 @@ workflows:
                 job_type: build
                 environment_type: development
   publish_auto_versioning:
+    depends:
+      - build
     jobs:
       - publish_auto_versioning:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,37 +90,6 @@ jobs:
           arguments: |
             --acl public-read \
             --cache-control "max-age=3600"
-  publish_auto_versioning:
-      <<: *defaults
-      steps:
-        - checkout
-        - restore_cache:
-            keys:
-              - v1-dependencies-{{ checksum "package-lock.json" }}
-        - run: npm install
-        - save_cache:
-            paths:
-              - node_modules
-            key: v1-dependencies-{{ checksum "package-lock.json" }}
-        - run: npm run build
-        - run: ./scripts/create-version.sh
-        - run:
-            name: Authenticate with registry
-            command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/.npmrc
-        - run:
-            name: Publish core components to npm
-            command: npm publish --access=public .
-        - run: cd angular && npm install
-        - run:
-            name: Build Angular components
-            command: cd angular && npm run build
-        - run:
-            name: Authenticate with registry in Angular components output directory
-            command: echo "//registry.npmjs.org/:_authToken=$NPM_PUBLISH_AUTH_TOKEN" > ~/components/angular/dist/components/.npmrc
-        - run:
-            name: Publish Angular components to npm
-            command: cd angular/dist/components && npm publish --access=public .
-
   # Publishes `@biggive/components` *and* `@biggive/components-angular` (building both on the fly).
   publish:
     <<: *defaults
@@ -134,6 +103,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package-lock.json" }}
+      - run: ./scripts/create-version.sh
       - run: npm run build
       - run:
           name: Authenticate with registry
@@ -164,24 +134,14 @@ workflows:
             - jira/notify:
                 job_type: build
                 environment_type: development
-      - publish_auto_versioning:
-          requires:
-            - build
-          filters:
-            branches:
-              only: COM-14-auto-versioning
-          context:
-            - docker-hub-creds
-            - jira
-            - npm-publish
   publish:
     jobs:
       - publish:
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - main
+                - COM-14-auto-versioning
           context:
             - docker-hub-creds
             - jira

--- a/angular/projects/components/package.json
+++ b/angular/projects/components/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@biggive/components-angular",
   "description": "Angular-packaged components for @biggive apps",
-  "version": "1.0.199",
+  "_comment": "Version number below is automatically replaced during CircleCI build.",
+  "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^14.1.0||^15.0.4",
     "@angular/core": "^14.1.0||^15.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@biggive/components",
-  "version": "2023.1.1-9.18.11.55",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@biggive/components",
-      "version": "2023.1.1-9.18.11.55",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@biggive/components",
-  "version": "1.0.199",
+  "version": "2023.1.1-9.18.3.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@biggive/components",
-      "version": "1.0.199",
+      "version": "2023.1.1-9.18.3.45",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@biggive/components",
-  "version": "2023.1.1-9.18.3.45",
+  "version": "2023.1.1-9.18.11.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@biggive/components",
-      "version": "2023.1.1-9.18.3.45",
+      "version": "2023.1.1-9.18.11.55",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biggive/components",
-  "version": "2023.1.1-9.18.3.45",
+  "version": "2023.1.1-9.18.11.55",
   "description": "Big Give Components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biggive/components",
-  "version": "1.0.199",
+  "version": "2023.1.1-9.18.3.45",
   "description": "Big Give Components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@biggive/components",
-  "version": "2023.1.1-9.18.11.55",
+  "_comment": "Version number below is automatically replaced during CircleCI build.",
+  "version": "0.0.1",
   "description": "Big Give Components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -11,8 +11,8 @@ VERSION_NUMBER=`date +%Y.%m.%d.%H.%M.%S`
 
 echo $VERSION_NUMBER
 
-npm version $VERSION_NUMBER
+npm version --no-git-tag-version $VERSION_NUMBER
 cd angular
-npm version $VERSION_NUMBER
+npm version --no-git-tag-version $VERSION_NUMBER
 
 git diff

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -7,7 +7,9 @@ cd "$(dirname "$0")"/..
 
 set -x
 
-VERSION_NUMBER=`date +%Y.%m.%d.%H.%M.%S`
+# Generate a version number such as v202301201056.0.0
+# Publishing will fail and have to be manually retried if this script is used twice in the same minute.
+VERSION_NUMBER=`date +%Y%m%d%H%M.0.0`
 
 echo $VERSION_NUMBER
 

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -15,4 +15,3 @@ npm version --no-git-tag-version $VERSION_NUMBER
 cd angular
 npm version --no-git-tag-version $VERSION_NUMBER
 
-git diff

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -9,6 +9,7 @@ set -x
 
 # Generate a version number such as v202301201056.0.0
 # Publishing will fail and have to be manually retried if this script is used twice in the same minute.
+# Making the major part of the version number change every minute means we technically comply with semver, but we never formally guarantee the absence of BC breaks.
 VERSION_NUMBER=`date +%Y%m%d%H%M.0.0`
 
 echo $VERSION_NUMBER

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -16,3 +16,8 @@ echo $VERSION_NUMBER
 npm version --no-git-tag-version $VERSION_NUMBER
 cd angular/projects/components
 npm version --no-git-tag-version $VERSION_NUMBER
+
+echo "New version number is $VERSION_NUMBER. Packages will be published to:"
+echo
+echo "https://www.npmjs.com/package/@biggive/components-angular/v/$VERSION_NUMBER"
+echo "https://www.npmjs.com/package/@biggive/components/v/$VERSION_NUMBER"

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -12,6 +12,5 @@ VERSION_NUMBER=`date +%Y.%m.%d.%H.%M.%S`
 echo $VERSION_NUMBER
 
 npm version --no-git-tag-version $VERSION_NUMBER
-cd angular
+cd projects/components
 npm version --no-git-tag-version $VERSION_NUMBER
-

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -12,5 +12,5 @@ VERSION_NUMBER=`date +%Y.%m.%d.%H.%M.%S`
 echo $VERSION_NUMBER
 
 npm version --no-git-tag-version $VERSION_NUMBER
-cd projects/components
+cd angular/projects/components
 npm version --no-git-tag-version $VERSION_NUMBER

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -3,4 +3,16 @@
 # Bash strict mode // http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
 IFS=$'\n\t'
+cd "$(dirname "$0")"/..
 
+set -x
+
+VERSION_NUMBER=`date +%Y.%m.%d.%H.%M.%S`
+
+echo $VERSION_NUMBER
+
+npm version $VERSION_NUMBER
+cd angular
+npm version $VERSION_NUMBER
+
+git diff

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Bash strict mode // http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+


### PR DESCRIPTION
This should mean we no longer need to create any tags or manually update any versions to publish components to NPM. Instead whenever a commit is merged to `main` (or to the branch of this PR) a version number is auto generated based on the time such as `v202301201120.0.0` (i.e. 11:20 on Jan 20 2022), and published to NPM.