### PR TITLE
Refactor: Rename colour variables to have more understandable names

### DIFF
--- a/src/components/biggive-branded-image/biggive-branded-image.scss
+++ b/src/components/biggive-branded-image/biggive-branded-image.scss
@@ -11,7 +11,7 @@
   .slug {
     text-align: center;
     font-weight: bold;
-    background-color: $colour-secondary;
+    background-color: $colour-secondary-green;
     color: $colour-black;
     padding: $spacer-1 $spacer-3;
     width: 100%;
@@ -58,7 +58,7 @@
   }
 
   #charityName {
-    color: $colour-primary;
+    color: $colour-primary-blue;
     display: block;
     margin-bottom: 5px;
     width: fit-content; // so link doesn't go full width
@@ -66,7 +66,7 @@
 
   #charityName, .charity-info {
     font-size: 17px;
-    
+
     @media screen and (max-width: $screen-tablet-max) {
       font-size: 16px;
     }

--- a/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.scss
+++ b/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.scss
@@ -74,7 +74,7 @@
           vertical-align: top;
 
           &:hover {
-            fill: $colour-primary;
+            fill: $colour-primary-blue;
           }
         }
       }
@@ -87,7 +87,7 @@
   margin: auto;
 
   > path {
-    fill: $colour-primary;
+    fill: $colour-primary-blue;
   }
 }
 
@@ -128,5 +128,5 @@
 }
 
 .text-colour-primary {
-  color: $colour-primary;
+  color: $colour-primary-blue;
 }

--- a/src/components/biggive-campaign-card/biggive-campaign-card.scss
+++ b/src/components/biggive-campaign-card/biggive-campaign-card.scss
@@ -31,7 +31,7 @@
     text-align: center;
     font-weight: bold;
     span {
-      background-color: $colour-secondary;
+      background-color: $colour-secondary-green;
       color: $colour-black;
       padding: $spacer-1 $spacer-3;
       display: inline-block;
@@ -56,7 +56,7 @@
   }
   .organisation-name {
     margin-bottom: $spacer-4;
-    color: $colour-primary;
+    color: $colour-primary-blue;
   }
   .meta-wrap {
     @include flex-container-row();
@@ -75,7 +75,7 @@
       &:last-child {
         text-align: right;
         .text {
-          color: $colour-primary;
+          color: $colour-primary-blue;
         }
       }
     }

--- a/src/components/biggive-campaign-highlights/biggive-campaign-highlights.scss
+++ b/src/components/biggive-campaign-highlights/biggive-campaign-highlights.scss
@@ -21,7 +21,7 @@
     text-align: center;
     font-weight: bold;
     span {
-      background-color: $colour-secondary;
+      background-color: $colour-secondary-green;
       color: $colour-black;
       padding: $spacer-1 $spacer-3;
       display: inline-block;
@@ -56,11 +56,11 @@
         @media screen and (max-width: $screen-tablet-max) {
           font-size: 23px;
         }
-    
+
         @media screen and (max-width: $screen-mobile-max) {
           font-size: 21px;;
         }
-    
+
         @media screen and (max-width: $screen-mobile-small) {
           font-size: 17px;
         }
@@ -68,7 +68,7 @@
       &:last-child {
         text-align: right;
         .text {
-          color: $colour-primary;
+          color: $colour-primary-blue;
         }
       }
     }
@@ -90,7 +90,7 @@
         position: relative;
         bottom: 7px;
       }
-  
+
       @media screen and (max-width: $screen-mobile-max) {
         @include font-size-small();
         margin: auto 0;
@@ -102,7 +102,7 @@
       }
 
       svg {
-        fill: $colour-tertiary;
+        fill: $colour-tertiary-coral;
       }
     }
   }
@@ -133,7 +133,7 @@
     a {
       text-decoration: none;
       font-weight: bold;
-      color: $colour-primary;
+      color: $colour-primary-blue;
       @media screen and (max-width: $screen-mobile-small) {
         // Show Champion Name on new line in smaller screens
         display: block;
@@ -142,6 +142,6 @@
   }
 
   @media screen and (max-width: $screen-mobile-max) {
-    padding: 15px; 
+    padding: 15px;
   }
 }

--- a/src/components/biggive-footer/biggive-footer.scss
+++ b/src/components/biggive-footer/biggive-footer.scss
@@ -75,7 +75,7 @@ nav ul li a {
   background-repeat: no-repeat;
   background-size: auto 75px;
   background-position: $spacer-6 30px;
-  background-color: $colour-primary;
+  background-color: $colour-primary-blue;
   padding: 100px $spacer-6 $spacer-6 $spacer-6;
   display: flex;
   flex-wrap: wrap;

--- a/src/components/biggive-form-field-select-option/biggive-form-field-select-option.scss
+++ b/src/components/biggive-form-field-select-option/biggive-form-field-select-option.scss
@@ -7,7 +7,7 @@
   @include standard-font();
   padding: 2px $spacer-2;
   &:hover {
-    background-color: $colour-primary;
+    background-color: $colour-primary-blue;
     color: $colour-white;
     cursor: pointer;
   }

--- a/src/components/biggive-form-field-select/biggive-form-field-select.scss
+++ b/src/components/biggive-form-field-select/biggive-form-field-select.scss
@@ -21,9 +21,9 @@
     z-index: 1;
     left: 0;
     right: 0;
-    border-left: 1px solid $colour-primary;
-    border-right: 1px solid $colour-primary;
-    border-bottom: 1px solid $colour-primary;
+    border-left: 1px solid $colour-primary-blue;
+    border-right: 1px solid $colour-primary-blue;
+    border-bottom: 1px solid $colour-primary-blue;
   }
   &.active .options {
       display: block;

--- a/src/components/biggive-header/biggive-header.scss
+++ b/src/components/biggive-header/biggive-header.scss
@@ -90,7 +90,7 @@
 
 .row-top {
   padding: $spacer-2 $spacer-4;
-  background-color: $colour-primary;
+  background-color: $colour-primary-blue;
   display: flex;
   .social-icon-wrap {
     margin-right: $spacer-3;
@@ -222,7 +222,7 @@
       }
 
       a:hover {
-        color: $colour-primary;
+        color: $colour-primary-blue;
       }
 
       ul {
@@ -311,7 +311,7 @@
       &.active {
         background-image: url(/assets/images/cross.svg?1);
         display: block;
-        background-color: $colour-primary;
+        background-color: $colour-primary-blue;
         background-size: 50% 50%;
         width: 30px;
         height: 30px;

--- a/src/components/biggive-heading/biggive-heading.scss
+++ b/src/components/biggive-heading/biggive-heading.scss
@@ -8,9 +8,9 @@
 
 .container {
   @include standard-font();
-  .heading-colour-primary { color: $colour-primary; }
-  .heading-colour-secondary { color: $colour-secondary; }
-  .heading-colour-tertiary { color: $colour-tertiary; }
+  .heading-colour-primary { color: $colour-primary-blue; }
+  .heading-colour-secondary { color: $colour-secondary-green; }
+  .heading-colour-tertiary { color: $colour-tertiary-coral; }
   .heading-colour-white { color: $colour-white; }
   .heading-colour-black { color: $colour-black; }
 }

--- a/src/components/biggive-hero-image/biggive-hero-image.scss
+++ b/src/components/biggive-hero-image/biggive-hero-image.scss
@@ -12,9 +12,9 @@
   overflow: hidden;
   position: relative;
   margin-bottom: $spacer-4;
-  &.colour-scheme-primary { color: $colour-primary; }
-  &.colour-scheme-secondary {  color: $colour-secondary; }
-  &.colour-scheme-tertiary { color: $colour-tertiary; }
+  &.colour-scheme-primary { color: $colour-primary-blue; }
+  &.colour-scheme-secondary {  color: $colour-secondary-green; }
+  &.colour-scheme-tertiary { color: $colour-tertiary-coral; }
   &.colour-scheme-white { color: $colour-white; }
   &.colour-scheme-black { color: $colour-black; }
   .sleeve {
@@ -51,7 +51,7 @@
         }
         @media (max-width: $screen-mobile-max) {
           width: 180px;
-        } 
+        }
       }
     }
     .slug {

--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -54,7 +54,7 @@ a {
 
 .row-top {
   padding: $spacer-2 $spacer-4;
-  background-color: $colour-primary;
+  background-color: $colour-primary-blue;
   display: flex;
 
   .social-icon-wrap {
@@ -337,7 +337,7 @@ nav {
             #mobileLogo {
               width: 130px;
             }
-  
+
           }
 
           #x {
@@ -361,7 +361,7 @@ nav {
           li {
             display: block;
             border-bottom: 1px solid #e6e6e6;
-			
+
             a {
               width: 100%;
               display: block;

--- a/src/components/biggive-page-section/biggive-page-section.scss
+++ b/src/components/biggive-page-section/biggive-page-section.scss
@@ -17,7 +17,7 @@
 
 .container.full-bleed {
   // from https://stackoverflow.com/questions/22083157/extend-background-color-of-header-beyond-container-with-css
-  box-shadow: 0 0 0 100vmax $colour-primary;
+  box-shadow: 0 0 0 100vmax $colour-primary-blue;
   clip-path: inset(0 -100vmax);
 }
 
@@ -94,7 +94,7 @@
 .container.background-color-primary:after,
 .container.background-color-primary .sleeve,
 .container.background-color-primary .sleeve:before {
-  background-color: $colour-primary;
+  background-color: $colour-primary-blue;
   color: $colour-white;
 }
 
@@ -102,7 +102,7 @@
 .container.background-color-secondary:after,
 .container.background-color-secondary .sleeve:before,
 .container.background-color-secondary .sleeve {
-  background-color: $colour-secondary;
+  background-color: $colour-secondary-green;
   color: $colour-white;
 }
 
@@ -110,7 +110,7 @@
 .container.background-color-tertiary:after,
 .container.background-color-tertiary .sleeve:before,
 .container.background-color-tertiary .sleeve {
-  background-color: $colour-tertiary;
+  background-color: $colour-tertiary-coral;
   color: $colour-white;
 }
 
@@ -118,7 +118,7 @@
 .container.background-color-brand-1:after,
 .container.background-color-brand-1 .sleeve:before,
 .container.background-color-brand-1 .sleeve {
-  background-color: $colour-brand-1;
+  background-color: $colour-brand-red;
   color: $colour-white;
 }
 
@@ -126,7 +126,7 @@
 .container.background-color-brand-2:after,
 .container.background-color-brand-2 .sleeve:before,
 .container.background-color-brand-2 .sleeve {
-  background-color: $colour-brand-2;
+  background-color: $colour-brand-purple;
   color: $colour-white;
 }
 
@@ -134,7 +134,7 @@
 .container.background-color-brand-3:after,
 .container.background-color-brand-3 .sleeve:before,
 .container.background-color-brand-3 .sleeve {
-  background-color: $colour-brand-3;
+  background-color: $colour-brand-green;
   color: $colour-white;
 }
 
@@ -142,7 +142,7 @@
 .container.background-color-brand-4:after,
 .container.background-color-brand-4 .sleeve:before,
 .container.background-color-brand-4 .sleeve {
-  background-color: $colour-brand-4;
+  background-color: $colour-brand-yellow;
   color: $colour-white;
 }
 
@@ -150,7 +150,7 @@
 .container.background-color-brand-5:after,
 .container.background-color-brand-5 .sleeve:before,
 .container.background-color-brand-5 .sleeve {
-  background-color: $colour-brand-5;
+  background-color: $colour-brand-orange;
   color: $colour-white;
 }
 
@@ -158,7 +158,7 @@
 .container.background-color-brand-6:after,
 .container.background-color-brand-6 .sleeve:before,
 .container.background-color-brand-6 .sleeve {
-  background-color: $colour-brand-6;
+  background-color: $colour-brand-grey;
   color: $colour-white;
 }
 

--- a/src/components/biggive-search/biggive-search.scss
+++ b/src/components/biggive-search/biggive-search.scss
@@ -12,9 +12,9 @@
       width: 0;
       height: 0;
       position: absolute;
-      border-right: 50px solid  transparent; 
+      border-right: 50px solid  transparent;
       border-left: 50px solid  transparent;
-      border-bottom: 86.60254px solid $colour-secondary;
+      border-bottom: 86.60254px solid $colour-secondary-green;
     }
 
     .triangle-before {
@@ -35,7 +35,7 @@
       @include standard-font();
       padding: 1.5rem;
       box-sizing: border-box;
-    
+
       h2 {
         width: 100%;
         font-weight: 500;
@@ -43,29 +43,29 @@
         margin-bottom: 0px;
         font-size: 1.2rem;
       }
-    
+
       .search-box {
         display: flex;
         padding: 10px 10px 5px 10px;
         margin-top: 1rem;
         margin-bottom: 1.25rem;
         border-bottom: 1px solid black;
-    
+
         .icon {
           @include icon();
           margin: auto;
 
           > path {
-            fill: $colour-primary;
+            fill: $colour-primary-blue;
           }
         }
-    
+
         #x-icon {
           &:hover {
             cursor: pointer;
           }
         }
-      
+
         input {
           @include standard-font();
           width: 100%;
@@ -73,28 +73,28 @@
           border: none;
           border-radius: 3px;
           font-size: 1.1rem;
-      
+
           &::placeholder {
             color: rgb(150, 150, 150);
           }
-      
+
           &:focus {
             outline: none;
           }
         }
       }
-    
+
       button {
         @include standard-font();
         width: 100%;
         padding: 0.75rem;
         box-sizing: border-box;
-        background-color: $colour-primary;
+        background-color: $colour-primary-blue;
         color: white;
         border: none;
         border-radius: 5px;
         font-size: 1rem;
-    
+
         &:hover {
           cursor: pointer;
           background-color: navy;

--- a/src/globals/mixins.scss
+++ b/src/globals/mixins.scss
@@ -224,15 +224,15 @@
   transition: all ease-in-out 0.5s;
   display: inline-block;
   margin-right: 10px;
-  &.colour-scheme-primary {background-color: $colour-primary; svg {fill: $colour-white;}}
-  &.colour-scheme-secondary {background-color: $colour-secondary; svg {fill: $colour-black;}}
-  &.colour-scheme-tertiary {background-color: $colour-tertiary; svg {fill: $colour-black;}}
-  &.colour-scheme-brand-1 {background-color: $colour-brand-1; svg {fill: $colour-black;}}
-  &.colour-scheme-brand-2 {background-color: $colour-brand-2; svg {fill: $colour-black;}}
-  &.colour-scheme-brand-3 {background-color: $colour-brand-3; svg {fill: $colour-black;}}
-  &.colour-scheme-brand-4 {background-color: $colour-brand-4; svg {fill: $colour-black;}}
-  &.colour-scheme-brand-5 {background-color: $colour-brand-5; svg {fill: $colour-black;}}
-  &.colour-scheme-brand-6 {background-color: $colour-brand-6; svg {fill: $colour-black;}}
+  &.colour-scheme-primary {background-color: $colour-primary-blue; svg {fill: $colour-white;}}
+  &.colour-scheme-secondary {background-color: $colour-secondary-green; svg {fill: $colour-black;}}
+  &.colour-scheme-tertiary {background-color: $colour-tertiary-coral; svg {fill: $colour-black;}}
+  &.colour-scheme-brand-1 {background-color: $colour-brand-red; svg {fill: $colour-black;}}
+  &.colour-scheme-brand-2 {background-color: $colour-brand-purple; svg {fill: $colour-black;}}
+  &.colour-scheme-brand-3 {background-color: $colour-brand-green; svg {fill: $colour-black;}}
+  &.colour-scheme-brand-4 {background-color: $colour-brand-yellow; svg {fill: $colour-black;}}
+  &.colour-scheme-brand-5 {background-color: $colour-brand-orange; svg {fill: $colour-black;}}
+  &.colour-scheme-brand-6 {background-color: $colour-brand-grey; svg {fill: $colour-black;}}
   &.colour-scheme-white {background-color: $colour-white; svg {fill: $colour-black;}}
   &.colour-scheme-black {background-color: $colour-black; svg {fill: $colour-white;}}
   &:hover {
@@ -293,22 +293,22 @@
 @mixin progress-bar-primary {
   .slider {
     .progress {
-      background-color: $colour-primary;
+      background-color: $colour-primary-blue;
     }
   }
   .counter {
-    color: $colour-primary;
+    color: $colour-primary-blue;
   }
 }
 
 @mixin progress-bar-secondary {
   .slider {
     .progress {
-      background-color: $colour-secondary;
+      background-color: $colour-secondary-green;
     }
   }
   .counter {
-    color: $colour-secondary;
+    color: $colour-secondary-green;
   }
 }
 
@@ -330,11 +330,11 @@
   @include font-size-medium();
   padding: 1px;
   position: relative;
-  background-color: $colour-primary;
+  background-color: $colour-primary-blue;
   @include corner-clip-small-top-right();
   span.placeholder {
     background-color: $colour-white;
-    color: $colour-primary;
+    color: $colour-primary-blue;
     display: block;
     position: relative;
     padding: 10px 80px 10px 10px;
@@ -399,7 +399,7 @@
 }
 
 @mixin button-clear-primary {
-  color: $colour-primary;
+  color: $colour-primary-blue;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -412,7 +412,7 @@
 }
 
 @mixin button-clear-secondary {
-  color: $colour-secondary;
+  color: $colour-secondary-green;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -425,7 +425,7 @@
 }
 
 @mixin button-clear-tertiary {
-  color: $colour-tertiary;
+  color: $colour-tertiary-coral;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -438,7 +438,7 @@
 }
 
 @mixin button-clear-brand-1 {
-  color: $colour-brand-1;
+  color: $colour-brand-red;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -451,7 +451,7 @@
 }
 
 @mixin button-clear-brand-2 {
-  color: $colour-brand-2;
+  color: $colour-brand-purple;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -464,7 +464,7 @@
 }
 
 @mixin button-clear-brand-3 {
-  color: $colour-brand-3;
+  color: $colour-brand-green;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -477,7 +477,7 @@
 }
 
 @mixin button-clear-brand-4 {
-  color: $colour-brand-4;
+  color: $colour-brand-yellow;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -490,7 +490,7 @@
 }
 
 @mixin button-clear-brand-5 {
-  color: $colour-brand-5;
+  color: $colour-brand-orange;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -503,7 +503,7 @@
 }
 
 @mixin button-clear-brand-6 {
-  color: $colour-brand-6;
+  color: $colour-brand-grey;
   background-color: transparent;
   text-decoration: underline;
   border: 0;
@@ -531,21 +531,21 @@
 
 @mixin button-primary {
   color: $colour-white;
-  background-color: $colour-primary;
-  border-color: $colour-primary;
+  background-color: $colour-primary-blue;
+  border-color: $colour-primary-blue;
   &:hover {
-    color: $colour-primary;
+    color: $colour-primary-blue;
     background-color: $colour-white;
   }
 }
 
 @mixin button-white {
-  color: $colour-primary;
+  color: $colour-primary-blue;
   background-color: $colour-white;
   border-color: $colour-white;
   &:hover {
     color: $colour-black;
-    background-color: $colour-secondary;
+    background-color: $colour-secondary-green;
   }
 }
 
@@ -561,8 +561,8 @@
 
 @mixin button-secondary {
   color: $colour-black;
-  background-color: $colour-secondary;
-  border-color: $colour-secondary;
+  background-color: $colour-secondary-green;
+  border-color: $colour-secondary-green;
   &:hover {
     background-color: $colour-white;
     border-color: $colour-black;
@@ -571,8 +571,8 @@
 
 @mixin button-tertiary {
   color: $colour-white;
-  background-color: $colour-tertiary;
-  border-color: $colour-tertiary;
+  background-color: $colour-tertiary-coral;
+  border-color: $colour-tertiary-coral;
   &:hover {
     background-color: $colour-white;
   }
@@ -580,8 +580,8 @@
 
 @mixin button-brand-1 {
   color: $colour-white;
-  background-color: $colour-brand-1;
-  border-color: $colour-brand-1;
+  background-color: $colour-brand-red;
+  border-color: $colour-brand-red;
   &:hover {
     background-color: $colour-white;
   }
@@ -589,8 +589,8 @@
 
 @mixin button-brand-2 {
   color: $colour-white;
-  background-color: $colour-brand-2;
-  border-color: $colour-brand-2;
+  background-color: $colour-brand-purple;
+  border-color: $colour-brand-purple;
   &:hover {
     background-color: $colour-white;
   }
@@ -598,8 +598,8 @@
 
 @mixin button-brand-3 {
   color: $colour-white;
-  background-color: $colour-brand-3;
-  border-color: $colour-brand-3;
+  background-color: $colour-brand-green;
+  border-color: $colour-brand-green;
   &:hover {
     background-color: $colour-white;
   }
@@ -607,8 +607,8 @@
 
 @mixin button-brand-4 {
   color: $colour-white;
-  background-color: $colour-brand-4;
-  border-color: $colour-brand-4;
+  background-color: $colour-brand-yellow;
+  border-color: $colour-brand-yellow;
   &:hover {
     background-color: $colour-black;
   }
@@ -616,8 +616,8 @@
 
 @mixin button-brand-5 {
   color: $colour-white;
-  background-color: $colour-brand-5;
-  border-color: $colour-brand-5;
+  background-color: $colour-brand-orange;
+  border-color: $colour-brand-orange;
   &:hover {
     background-color: $colour-white;
   }
@@ -625,8 +625,8 @@
 
 @mixin button-brand-6 {
   color: $colour-white;
-  background-color: $colour-brand-6;
-  border-color: $colour-brand-6;
+  background-color: $colour-brand-grey;
+  border-color: $colour-brand-grey;
   &:hover {
     background-color: $colour-black;
   }
@@ -647,7 +647,7 @@
   height: 0;
   border-style: inset;
   border-width: $height $width 0 $width;
-  border-color: $colour-secondary transparent transparent transparent;
+  border-color: $colour-secondary-green transparent transparent transparent;
   float: left;
   transform: rotate(360deg);
 
@@ -660,7 +660,7 @@
     width: $width;
     height: $width;
     margin: 0;
-    color: $colour-primary;
+    color: $colour-primary-blue;
     font-size: $text-size;
   }
 }
@@ -783,7 +783,7 @@
       position: absolute;
       top: $spacer-2;
       right: $spacer-2;
-      background-color: $colour-primary;
+      background-color: $colour-primary-blue;
       background-image: url(/assets/images/cross.svg?1);
       background-size: 50% 50%;
       background-position: center center;
@@ -821,47 +821,47 @@
 @mixin backgrounds {
   .background-colour-hover-primary:hover,
   .background-colour-primary {
-      background-color: $colour-primary;
+      background-color: $colour-primary-blue;
   }
 
   .background-colour-hover-secondary:hover,
   .background-colour-secondary {
-      background-color: $colour-secondary;
+      background-color: $colour-secondary-green;
   }
 
   .background-colour-hover-tertiary:hover,
   .background-colour-tertiary {
-      background-color: $colour-tertiary;
+      background-color: $colour-tertiary-coral;
   }
 
   .background-colour-hover-brand-1:hover,
   .background-colour-brand-1 {
-      background-color: $colour-brand-1;
+      background-color: $colour-brand-red;
   }
 
   .background-colour-hover-brand-2:hover,
   .background-colour-brand-2 {
-      background-color: $colour-brand-2;
+      background-color: $colour-brand-purple;
   }
 
   .background-colour-hover-brand-3:hover,
   .background-colour-brand-3 {
-      background-color: $colour-brand-3;
+      background-color: $colour-brand-green;
   }
 
   .background-colour-hover-brand-4:hover,
   .background-colour-brand-4 {
-      background-color: $colour-brand-4;
+      background-color: $colour-brand-yellow;
   }
 
   .background-colour-hover-brand-5:hover,
   .background-colour-brand-5 {
-      background-color: $colour-brand-5;
+      background-color: $colour-brand-orange;
   }
 
   .background-colour-hover-brand-6:hover,
   .background-colour-brand-6 {
-      background-color: $colour-brand-6;
+      background-color: $colour-brand-grey;
   }
 
   .background-colour-hover-white:hover,
@@ -877,39 +877,39 @@
 
 @mixin fills {
   .fill-primary {
-      fill: $colour-primary;
+      fill: $colour-primary-blue;
   }
 
   .fill-secondary {
-      fill: $colour-secondary;
+      fill: $colour-secondary-green;
   }
 
   .fill-tertiary {
-      fill: $colour-tertiary;
+      fill: $colour-tertiary-coral;
   }
 
   .fill-brand-1 {
-      fill: $colour-brand-1;
+      fill: $colour-brand-red;
   }
 
   .fill-brand-2 {
-      fill: $colour-brand-2;
+      fill: $colour-brand-purple;
   }
 
   .fill-brand-3 {
-      fill: $colour-brand-3;
+      fill: $colour-brand-green;
   }
 
   .fill-brand-4 {
-      fill: $colour-brand-4;
+      fill: $colour-brand-yellow;
   }
 
   .fill-brand-5 {
-      fill: $colour-brand-5;
+      fill: $colour-brand-orange;
   }
 
   .fill-brand-6 {
-      fill: $colour-brand-6;
+      fill: $colour-brand-grey;
   }
 
   .fill-white {
@@ -974,47 +974,47 @@
 @mixin text-colours {
   .text-colour-hover-primary:hover,
   .text-colour-primary {
-      color: $colour-primary;
+      color: $colour-primary-blue;
   }
 
   .text-colour-hover-secondary:hover,
   .text-colour-secondary {
-      color: $colour-secondary;
+      color: $colour-secondary-green;
   }
 
   .text-colour-hover-tertiary:hover,
   .text-colour-tertiary {
-      color: $colour-tertiary;
+      color: $colour-tertiary-coral;
   }
 
   .text-colour-hover-brand-1:hover,
   .text-colour-brand-1 {
-      color: $colour-brand-1;
+      color: $colour-brand-red;
   }
 
   .text-colour-hover-brand-2:hover,
   .text-colour-brand-2 {
-      color: $colour-brand-2;
+      color: $colour-brand-purple;
   }
 
   .text-colour-hover-brand-3:hover,
   .text-colour-brand-3 {
-      color: $colour-brand-3;
+      color: $colour-brand-green;
   }
 
   .text-colour-hover-brand-4:hover,
   .text-colour-brand-4 {
-      color: $colour-brand-4;
+      color: $colour-brand-yellow;
   }
 
   .text-colour-hover-brand-5:hover,
   .text-colour-brand-5 {
-      color: $colour-brand-5;
+      color: $colour-brand-orange;
   }
 
   .text-colour-hover-brand-6:hover,
   .text-colour-brand-6 {
-      color: $colour-brand-6;
+      color: $colour-brand-grey;
   }
 
   .text-colour-hover-white:hover,

--- a/src/globals/variables.scss
+++ b/src/globals/variables.scss
@@ -10,16 +10,16 @@ $screen-desktop-max: 1200px;
 
 $aspect-ratio-banners: percentage(0.30555); // 0.30555 is approx 352 / 1152
 
-$colour-primary: #2C089B;
-$colour-secondary: #2AF135;
-$colour-tertiary: #FF7272;
+$colour-primary-blue: #2C089B;
+$colour-secondary-green: #2AF135;
+$colour-tertiary-coral: #FF7272;
 
-$colour-brand-1: #B30510;
-$colour-brand-2: #6E0887;
-$colour-brand-3: #50B400;
-$colour-brand-4: #FFE500;
-$colour-brand-5: #F07D00;
-$colour-brand-6: #CBC8C8;
+$colour-brand-red: #B30510;
+$colour-brand-purple: #6E0887;
+$colour-brand-green: #50B400;
+$colour-brand-yellow: #FFE500;
+$colour-brand-orange: #F07D00;
+$colour-brand-grey: #CBC8C8;
 
 
 $colour-white: #FFFFFF;


### PR DESCRIPTION
When discussing designs with the team no-one says "Can you make that colour primary" or "I preferred it in brand 4". We talk about blue and yellow. This refactor should make it easier to map between those discussions and code.