### PR TITLE
DON-739: Space out main nav to make open subsubmenu items fully visible

### DIFF
--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -137,7 +137,7 @@ nav {
           align-items: center;
           justify-content: space-between;
           list-style: none;
-          padding: 0 14px;
+          padding: 0 20px;
 
           a {
             height: 100%;


### PR DESCRIPTION
Previously the Match Funding opportunties menu was too close to the right edge of the viewport, so that when you open the sub menu the sub-submen items get pushed of the edge of the screen.

Before:

![image](https://user-images.githubusercontent.com/159481/219433345-2f20101c-cdc3-4faa-9d5c-99b427d4b3aa.png)

After:

![image](https://user-images.githubusercontent.com/159481/219433578-da8ea252-d747-4de6-9b9b-76d9339236a2.png)


Separate PRs will be needed to pull changes into the donate-frontend and wordpress.