### PR TITLE
COM-55: Fix touch events on mobile menu

### DIFF
--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -101,7 +101,11 @@ export class BiggiveMainMenu {
     });
     this.setHeaderSize();
 
-    const subMenuElements = this.host.querySelectorAll<HTMLElement>('.sub-menu');
+    const subMenuElements = this.host.shadowRoot!.querySelectorAll<HTMLElement>('.sub-menu');
+    if (subMenuElements.length === 0) {
+      console.error('Missing subMenuElements');
+    }
+
     subMenuElements.forEach(subMenuElement => {
       // the subMenuLink is a sibling element to the actual sub-menu
       const subMenuLink = subMenuElement.parentElement?.querySelector('a');
@@ -113,7 +117,12 @@ export class BiggiveMainMenu {
       };
     });
 
-    const subSubMenuElements = this.host.querySelectorAll<HTMLElement>('.sub-sub-menu');
+    const subSubMenuElements = this.host.shadowRoot!.querySelectorAll<HTMLElement>('.sub-sub-menu');
+
+    if (subSubMenuElements.length === 0) {
+      console.error('Missing subSubMenuElements');
+    }
+
     subSubMenuElements.forEach(subSubMenuElement => {
       // the subSubMenuLink is a sibling element to the actual sub-sub-menu
       const subSubMenuLink = subSubMenuElement!.parentElement!.querySelector('a');


### PR DESCRIPTION
This was broken in commit 73c286d with the shift to hard-coded menu content in this repo. Not sure why we now need to find the elements in the shadowRoot. Querying them directly from the host returns an empty node list.

Menu now appears as below in mobile version of this library's index file and is usable again:

![image](https://user-images.githubusercontent.com/159481/230073190-be4a62a6-8817-4a9c-a1b9-ef1d70b6edc7.png)

There is still a visual regression compared to the old good version below, that this PR doesn't fix, but it fixes the reported bug which is the most urgent thing to fix. For reference this is the old version of the menu:

![image](https://user-images.githubusercontent.com/159481/230073460-7ed1f947-3759-4575-8406-a0f401d869d1.png)
