### PR TITLE
Add a maximum offset to deal with resize edge case

### DIFF
--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -91,7 +91,11 @@ export class BiggiveMainMenu {
   }
 
   setHeaderSize() {
-    document.body.style.paddingTop = this.host.offsetHeight + 'px';
+    // Some resize edge cases lead Firefox, and maybe others, to go haywire and get a host offset
+    // height of millions of pixels, presumably due to a layout logic loop. So for as long as we use
+    // this body padding workaround, we need a safe maximum value, currently 130px, beyond which
+    // we will never further displace the main content.
+    document.body.style.paddingTop = Math.min(130, this.host.offsetHeight).toString() + 'px';
   }
 
   componentDidRender() {


### PR DESCRIPTION
I've been working on Donate with the updates from https://github.com/thebiggive/components/pull/154 and a reduction in offset workarounds in Donate itself.

However Firefox, when resizing down from desktop size to a slightly smaller one, still has a very broken rendering edge case which occurs intermittently. It seems to correlate with an extremely high calculated body padding number, so this PR caps the maximum offset to make it a bit less broken for now.

When the bug occurs, the empty space usually first appears as the menu's blue, then sometimes appears white later. So far I can't replicate it on Chrome or Safari running the same code.

<img width="1402" alt="Screenshot 2023-04-11 at 11 20 45" src="https://user-images.githubusercontent.com/3274454/231134912-5c0b0e56-af6a-4369-8940-6009a23afefa.png">
