### PR TITLE
DON-812: Allow drop down to inherit text colour so it can be black no…

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -542,6 +542,7 @@ export namespace Components {
         "prompt": string | null;
         "selectStyle": 'bordered' | 'underlined';
         "selectedLabel": string | null;
+        "selectedOptionColour": 'inherit' | 'blue';
         "selectedValue": string | null;
         "selectionChanged": (value: string) => void;
         /**
@@ -2048,6 +2049,7 @@ declare namespace LocalJSX {
         "prompt": string | null;
         "selectStyle"?: 'bordered' | 'underlined';
         "selectedLabel"?: string | null;
+        "selectedOptionColour"?: 'inherit' | 'blue';
         "selectedValue"?: string | null;
         "selectionChanged"?: (value: string) => void;
         /**

--- a/src/components/biggive-form-field-select/biggive-form-field-select.scss
+++ b/src/components/biggive-form-field-select/biggive-form-field-select.scss
@@ -62,6 +62,10 @@ select.grey {
       @include dropdown-underlined();
     }
   }
+  &.select-style-underlined.inherit-colour select{
+   color: inherit;
+  }
+
   select {
     max-height: 200px;
     overflow-x: hidden;

--- a/src/components/biggive-form-field-select/biggive-form-field-select.tsx
+++ b/src/components/biggive-form-field-select/biggive-form-field-select.tsx
@@ -29,6 +29,8 @@ export class BiggiveFormFieldSelect {
    */
   @Prop() backgroundColour: 'white' | 'grey';
 
+  @Prop() selectedOptionColour: 'inherit' | 'blue' = 'blue';
+
   private doOptionSelectCompletedHandler = (event: any) => {
     const value = event.target.value;
     this.selectedValue = value;
@@ -66,7 +68,16 @@ export class BiggiveFormFieldSelect {
       <div class="selectWrapper">
         <label class={greyIfRequired}>
           <div class={'prompt' + greyIfRequired}>{this.prompt}</div>
-          <div class={'dropdown space-below-' + this.spaceBelow + ' select-style-' + this.selectStyle + (this.prompt === null ? '  noprompt' : '')}>
+          <div
+            class={
+              'dropdown space-below-' +
+              this.spaceBelow +
+              ' select-style-' +
+              this.selectStyle +
+              (this.prompt === null ? '  noprompt' : '') +
+              (this.selectedOptionColour === 'inherit' ? ' inherit-colour' : '')
+            }
+          >
             <div class="sleeve">
               <select class={greyIfRequired} onChange={this.doOptionSelectCompletedHandler}>
                 {Object.entries(options).map((value: [string, string]) => (

--- a/src/components/biggive-form-field-select/readme.md
+++ b/src/components/biggive-form-field-select/readme.md
@@ -7,17 +7,18 @@
 
 ## Properties
 
-| Property               | Attribute           | Description                                                                           | Type                                 | Default      |
-| ---------------------- | ------------------- | ------------------------------------------------------------------------------------- | ------------------------------------ | ------------ |
-| `backgroundColour`     | `background-colour` | Must match background of containing element, or unintended shape will appear.         | `"grey" \| "white"`                  | `undefined`  |
-| `options` _(required)_ | `options`           | JSON array of category key/values, or takes a stringified equiavalent (for Storybook) | `string \| { [x: string]: string; }` | `undefined`  |
-| `placeholder`          | `placeholder`       | Placeholder                                                                           | `string \| undefined`                | `undefined`  |
-| `prompt` _(required)_  | `prompt`            | Displayed as 'eyebrow' label over the top border of the box.                          | `null \| string`                     | `undefined`  |
-| `selectStyle`          | `select-style`      |                                                                                       | `"bordered" \| "underlined"`         | `'bordered'` |
-| `selectedLabel`        | `selected-label`    |                                                                                       | `null \| string`                     | `undefined`  |
-| `selectedValue`        | `selected-value`    |                                                                                       | `null \| string`                     | `undefined`  |
-| `selectionChanged`     | --                  |                                                                                       | `(value: string) => void`            | `undefined`  |
-| `spaceBelow`           | `space-below`       | Space below component                                                                 | `number`                             | `0`          |
+| Property               | Attribute                | Description                                                                           | Type                                 | Default      |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------ | ------------ |
+| `backgroundColour`     | `background-colour`      | Must match background of containing element, or unintended shape will appear.         | `"grey" \| "white"`                  | `undefined`  |
+| `options` _(required)_ | `options`                | JSON array of category key/values, or takes a stringified equiavalent (for Storybook) | `string \| { [x: string]: string; }` | `undefined`  |
+| `placeholder`          | `placeholder`            | Placeholder                                                                           | `string \| undefined`                | `undefined`  |
+| `prompt` _(required)_  | `prompt`                 | Displayed as 'eyebrow' label over the top border of the box.                          | `null \| string`                     | `undefined`  |
+| `selectStyle`          | `select-style`           |                                                                                       | `"bordered" \| "underlined"`         | `'bordered'` |
+| `selectedLabel`        | `selected-label`         |                                                                                       | `null \| string`                     | `undefined`  |
+| `selectedOptionColour` | `selected-option-colour` |                                                                                       | `"blue" \| "inherit"`                | `'blue'`     |
+| `selectedValue`        | `selected-value`         |                                                                                       | `null \| string`                     | `undefined`  |
+| `selectionChanged`     | --                       |                                                                                       | `(value: string) => void`            | `undefined`  |
+| `spaceBelow`           | `space-below`            | Space below component                                                                 | `number`                             | `0`          |
 
 
 ## Dependencies


### PR DESCRIPTION
…t blue on new donation page

It will remain blue on the explore campaigns page

Screenshot shows how it would look if the filter sort by black, although the plan is not to do that, but to make the country drop down black in the donation start page.

![image](https://github.com/thebiggive/components/assets/159481/4acfd500-7491-4cc2-9b21-c4162dd2d244)
