### PR TITLE
DON-812: Thicken select drop down border to match text input border

### DIFF
--- a/src/globals/mixins.scss
+++ b/src/globals/mixins.scss
@@ -332,7 +332,7 @@
 
 @mixin dropdown {
   @include font-size-medium();
-  padding: 1px;
+  padding: 2px;
   position: relative;
   background-color: $colour-primary-blue;
   @include corner-clip-small-top-right();


### PR DESCRIPTION
Before (with uncommited changes in index html):

![image](https://github.com/thebiggive/components/assets/159481/cfbb20cf-b3ce-47c6-9f63-c482d2adfae0)


After:

![image](https://github.com/thebiggive/components/assets/159481/ac9b90a6-5866-485a-b4dd-f098f6f9ba75)

