### PR TITLE
Fix filter grid display bug (bug was never in prod)

### DIFF
--- a/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
+++ b/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
@@ -196,7 +196,8 @@ export class BiggiveCampaignCardFilterGrid {
     for (const filterKey of Object.keys(filters)) {
       // https://stackoverflow.com/a/69757191/2803757
       const filterValue: string = filters[filterKey as keyof typeof filters];
-      if (filterValue?.length === 0) {
+
+      if (filterValue === null || filterValue.length === 0) {
         continue;
       }
 

--- a/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
+++ b/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
@@ -142,22 +142,8 @@ export class BiggiveCampaignCardFilterGrid {
     this.doSearchAndFilterUpdate.emit(this.getSearchAndFilterObject());
   };
 
-  private getSearchAndFilterObject(): {
-    searchText: string;
-    sortBy: string;
-    filterCategory: string;
-    filterBeneficiary: string;
-    filterLocation: string;
-    filterFunding: string;
-  } {
-    const event: {
-      searchText: string | null;
-      sortBy: string | null;
-      filterCategory: string | null;
-      filterBeneficiary: string | null;
-      filterLocation: string | null;
-      filterFunding: string | null;
-    } = {
+  private getSearchAndFilterObject() {
+    return {
       searchText: this.searchText,
       sortBy: this.selectedSortByOption,
       filterCategory: this.selectedFilterCategory,
@@ -165,9 +151,6 @@ export class BiggiveCampaignCardFilterGrid {
       filterFunding: this.selectedFilterFunding,
       filterLocation: this.selectedFilterLocation,
     };
-
-    // @ts-ignore
-    return event;
   }
 
   private handleApplyFilterButtonClick = () => {
@@ -195,7 +178,7 @@ export class BiggiveCampaignCardFilterGrid {
 
     for (const filterKey of Object.keys(filters)) {
       // https://stackoverflow.com/a/69757191/2803757
-      const filterValue: string = filters[filterKey as keyof typeof filters];
+      const filterValue = filters[filterKey as keyof typeof filters];
 
       if (filterValue === null || filterValue.length === 0) {
         continue;


### PR DESCRIPTION
Bug found in donate-fronted, also visible in the index.html file here

Before:

![image](https://github.com/thebiggive/components/assets/159481/ffaece16-c057-404d-bd56-07d83bcb310b)

After:

![image](https://github.com/thebiggive/components/assets/159481/ad17c1ad-d6e1-4873-ae19-4f58eb22db41)


We were displaying an empty button for every possible filter even if not selected.

Bug found during QA of DON-836 but not actually related to the Angular upgrade.