### PR TITLE
Revert "COM-50: upgrade stencil/core and stencil/sass"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
         "@fortawesome/pro-regular-svg-icons": "^6.1.2",
         "@fortawesome/pro-solid-svg-icons": "^6.1.2",
-        "@stencil/core": "^3.4.2"
+        "@stencil/core": "^2.13.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.9",
@@ -23,7 +23,7 @@
         "@babel/preset-typescript": "^7.22.5",
         "@stencil-community/eslint-plugin": "^0.5.0",
         "@stencil/angular-output-target": "^0.7.1",
-        "@stencil/sass": "^3.0.5",
+        "@stencil/sass": "^1.5.2",
         "@storybook/addon-actions": "^7.0.26",
         "@storybook/addon-essentials": "^7.0.26",
         "@storybook/addon-interactions": "^7.0.26",
@@ -4541,28 +4541,24 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ==",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=14.10.0",
+        "node": ">=12.10.0",
         "npm": ">=6.0.0"
       }
     },
     "node_modules/@stencil/sass": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.5.tgz",
-      "integrity": "sha512-9nyllMXOEvHywo6fP2iwXgnq32A+OOUE36Aq7iUjzwT3wdr04qsvupO1JNIyRvmvCDF15hOKXztrZH1/wDu2Zg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
+      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ==",
       "dev": true,
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      },
       "peerDependencies": {
-        "@stencil/core": ">=2.0.0 || >=3.0.0-beta.0 || >= 4.0.0-beta.0 || >= 4.0.0"
+        "@stencil/core": ">=1.0.2"
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -24132,14 +24128,14 @@
       "requires": {}
     },
     "@stencil/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ=="
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng=="
     },
     "@stencil/sass": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.5.tgz",
-      "integrity": "sha512-9nyllMXOEvHywo6fP2iwXgnq32A+OOUE36Aq7iUjzwT3wdr04qsvupO1JNIyRvmvCDF15hOKXztrZH1/wDu2Zg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
+      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
     "@fortawesome/pro-regular-svg-icons": "^6.1.2",
     "@fortawesome/pro-solid-svg-icons": "^6.1.2",
-    "@stencil/core": "^3.4.2"
+    "@stencil/core": "^2.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",
     "@babel/preset-env": "^7.22.7",
     "@babel/preset-typescript": "^7.22.5",
     "@stencil/angular-output-target": "^0.7.1",
-    "@stencil/sass": "^3.0.5",
+    "@stencil/sass": "^1.5.2",
     "@stencil-community/eslint-plugin": "^0.5.0",
     "@storybook/addon-actions": "^7.0.26",
     "@storybook/addon-essentials": "^7.0.26",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,10 +9,6 @@ import { spacingOption } from "./globals/spacing-option";
 import { brandColour } from "./globals/brand-colour";
 import { headingTag } from "./globals/heading-tag";
 import { headingSize } from "./globals/heading-size";
-export { spacingOption } from "./globals/spacing-option";
-export { brandColour } from "./globals/brand-colour";
-export { headingTag } from "./globals/heading-tag";
-export { headingSize } from "./globals/heading-size";
 export namespace Components {
     interface BiggiveAccordion {
         "headingColour": brandColour;


### PR DESCRIPTION
Reverts thebiggive/components#258
due to an error in [CircleCI](https://app.circleci.com/pipelines/github/thebiggive/components/1204/workflows/23519b40-244d-4516-bba2-b0c88003e7bb/jobs/1799), which we tried to fix with @bdsl
```
Building Angular Package

------------------------------------------------------------------------------
Building entry point '@biggive/components-angular'
------------------------------------------------------------------------------
- Compiling with Angular sources in Ivy partial compilation mode.
✖ Compiling with Angular sources in Ivy partial compilation mode.
projects/components/src/lib/stencil-generated/components.ts:7:15 - error TS2305: Module '"@biggive/components/dist/components"' has no exported member 'Components'.

7 import type { Components } from '@biggive/components/dist/components';
                ~~~~~~~~~~


Exited with code exit status 1