### PR TITLE
COM-50: Run Angular build on all commits in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm run build && git diff; git diff-index --quiet HEAD -- || (git status && exit 1); # Checks that npm run didn't change any files. If it did changes must be commited.
       - run: npm run lint
       - run: npm run test
+      - run: cd angular; npm install && npm run build
       - store_test_results:
           path: stencil-test-results
 


### PR DESCRIPTION
Previously this only ran when we were ready to actually publish to NPM. Running for all commits will help avoid merging anything that breaks the angular build