### PR TITLE
COM-88 – fix puppeteer 2nd run cache problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-dependencies-with-chrome-{{ checksum "package-lock.json" }}
+            - v4-dependencies-with-chrome-{{ checksum "package-lock.json" }}
       - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install --quiet
       - save_cache:
           paths:
             - node_modules
-          key: v3-dependencies-with-chrome-{{ checksum "package-lock.json" }}
+            - /home/circleci/.cache/puppeteer
+          key: v4-dependencies-with-chrome-{{ checksum "package-lock.json" }}
       - run: npm run build && git diff; git diff-index --quiet HEAD -- || (git status && exit 1); # Checks that npm run didn't change any files. If it did changes must be commited.
       - run: npm run lint
       - run: npm run test


### PR DESCRIPTION
(Hopefully!)

Based on:
```
[ ERROR ]  Could not find Chrome (ver. 114.0.5735.133).
           This can occur if either 1. you did not perform
           an installation before running the script (e.g.
           `npm install`) or 2. your cache path is
           incorrectly configured (which is:
           /home/circleci/.cache/puppeteer). For (2), check
           out our guide on configuring puppeteer at
           https://pptr.dev/guides/configuration.
```