### PR TITLE
COM-75: Allow shadows (and other content) to overflow from biggive-car…

### DIFF
--- a/src/components/biggive-carousel/biggive-carousel.scss
+++ b/src/components/biggive-carousel/biggive-carousel.scss
@@ -11,11 +11,9 @@
   position: relative;
 
   .items {
-    overflow: hidden;
     .sleeve {
       display: flex;
       min-width: 100%;
-      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
…ousel

Without the overflow the shadow doesn't look like a shadow, it just looks like a random dark background between the items.

Not sure why the overflow was put in - it's possible we will find that there are cases where we do neet it.