### PR TITLE
WPD-168: Add styling for Arts for Impact pink button

### DIFF
--- a/src/components/biggive-button/biggive-button.scss
+++ b/src/components/biggive-button/biggive-button.scss
@@ -1,7 +1,7 @@
 @include spacers();
 
 :host {
-  display: contents; 
+  display: contents;
 }
 
 .container {
@@ -22,7 +22,7 @@
     &.size-small {
       @include button-small();
     }
-    
+
     &.button.rounded-true {
       @include button-rounded();
     }
@@ -31,7 +31,7 @@
 .button-primary {
    @include button-primary();
 }
- 
+
 .button-secondary {
     @include button-secondary();
 }
@@ -68,6 +68,10 @@
     @include button-brand-6();
 }
 
+.button-brand-afa-pink {
+  @include button-brand-afa-pink();
+}
+
 .button-white {
     @include button-white();
 }
@@ -95,7 +99,7 @@
 .button-clear-primary {
     @include button-clear-primary();
 }
-  
+
 .button-clear-secondary {
     @include button-clear-secondary();
 }


### PR DESCRIPTION
Forgot to do this as part of https://github.com/thebiggive/components/pull/280 . 

This button should show as pink not black.

![image](https://github.com/thebiggive/components/assets/159481/e46602c5-c4de-4d19-b29f-c808dbc5157d)


Does seem like our colour code is really error prone as we have to add the new colour in a lot of places. Maybe next time we're adding a colour it will be worth refactoring to make it so there's just one (or not as many as there are now) place to add the next new colour.

Could also think about making it so the WP editing interface displays the names of the colours at the same time.