### PR TITLE
DON-783: Adjust style of cookie consent popup form

### DIFF
--- a/src/components/biggive-cookie-banner/biggive-cookie-banner.scss
+++ b/src/components/biggive-cookie-banner/biggive-cookie-banner.scss
@@ -34,3 +34,18 @@ div.button-group {
     flex-direction: row-reverse;
   }
 }
+
+biggive-popup {
+  @include font-size-medium();
+  div.content {
+    h5 {
+      border-bottom: 2px solid black;
+      max-width: 25em;
+      margin-bottom: 5px;
+    }
+
+    div.radio-group {
+      margin-bottom: 30px;
+    }
+  }
+}

--- a/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
+++ b/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
@@ -40,7 +40,7 @@ export class BiggiveCookieBanner {
     elementById.openFromOutside();
   };
 
-  private handleSavePreferencesClick = () => {
+  private handleAcceptSelectedCookies = () => {
     const elementById = this.el.shadowRoot?.getElementById('cookie-preferences-popup') as HTMLBiggivePopupElement;
     elementById.closeFromOutside();
 
@@ -62,40 +62,44 @@ export class BiggiveCookieBanner {
     return (
       <div class="cooke-consent-container">
         <biggive-popup id="cookie-preferences-popup">
-          <h4 class="space-above-0 space-below-3 text-colour-primary">Manage your cookie preferences</h4>
-          <form>
-            <h5>Essential (always required)</h5>
-            <input type="radio" name="necassary" id="necassary-off" disabled={true} />
-            <label htmlFor="necassary-on">Off</label>
+          <div class="content">
+            <h4 class="space-above-0 space-below-3 text-colour-primary">Manage your cookie preferences</h4>
+            <form>
+              <div class="radio-group">
+                <h5>Essential (always required)</h5>
+                <input type="radio" name="necassary" id="necassary-off" disabled={true} />
+                <label htmlFor="necassary-on">Off</label>
 
-            <input type="radio" name="necassary" id="necassary-on" disabled={true} checked={true} />
-            <label htmlFor="necassary-on">On</label>
+                <input type="radio" name="necassary" id="necassary-on" disabled={true} checked={true} />
+                <label htmlFor="necassary-on">On</label>
+              </div>
 
-            <h5>Marketing</h5>
-            <input type="radio" name="marketing" id="marketing-off" checked={true} />
-            <label htmlFor="marketing-off">Off</label>
+              <div class="radio-group">
+                <h5>Marketing</h5>
+                <input type="radio" name="marketing" id="marketing-off" checked={true} />
+                <label htmlFor="marketing-off">Off</label>
 
-            <input type="radio" name="marketing" id="marketing-on" />
-            <label htmlFor="marketing-on">On</label>
+                <input type="radio" name="marketing" id="marketing-on" />
+                <label htmlFor="marketing-on">On</label>
+              </div>
 
-            <hr />
-
-            <biggive-button
-              space-below="0"
-              space-above="2"
-              colour-scheme="secondary"
-              is-past-campaign="false"
-              is-future-campaign="false"
-              label="Save preferences"
-              open-in-new-tab="false"
-              full-width="false"
-              size="small"
-              rounded={false}
-              centered={false}
-              button-id="save-preferences-button"
-              onClick={this.handleSavePreferencesClick}
-            ></biggive-button>
-          </form>
+              <biggive-button
+                space-below="0"
+                space-above="2"
+                colour-scheme="secondary"
+                is-past-campaign="false"
+                is-future-campaign="false"
+                label="Accept Selected Cookies"
+                open-in-new-tab="false"
+                full-width="false"
+                size="small"
+                rounded={false}
+                centered={false}
+                button-id="accept-selected-button"
+                onClick={this.handleAcceptSelectedCookies}
+              ></biggive-button>
+            </form>
+          </div>
         </biggive-popup>
 
         <h2>Our website uses cookies</h2>


### PR DESCRIPTION
Before:

![image](https://github.com/thebiggive/components/assets/159481/e1b039c2-ad74-4d1b-9ff4-ed5736d9842a)

After:

![image](https://github.com/thebiggive/components/assets/159481/290e7355-4ea4-4f0d-81b9-de85d516e4ee)

I'd prefer the corners to be rounded, but that isn't an option in our popup component and I'm not sure it's worth building it just for this. I tried to get this a bit closer to what @thebiggive/devs suggested on Jira, plus match the appearance of the popup we have already for filter selection in explore shown below:

![image](https://github.com/thebiggive/components/assets/159481/ee2f13e4-c049-4c17-8c18-63a7b7a0e158)
