### PR TITLE
DON-783: Add support for embedding Vimeo videos (without setting cook…

### DIFF
--- a/src/components/biggive-video-feature/biggive-video-feature.tsx
+++ b/src/components/biggive-video-feature/biggive-video-feature.tsx
@@ -83,7 +83,7 @@ export class BiggiveVideoFeature {
             ) : null}
           </div>
           <div class="graphic-wrap">
-            {this.videoUrl !== null && this.videoUrl !== undefined ? <div class="video-wrap" innerHTML={VideoService.getEmbedHtml(this.videoUrl)}></div> : null}
+            {this.videoUrl !== null && this.videoUrl !== undefined ? <div class="video-wrap" innerHTML={VideoService.getEmbedHtml(this.videoUrl, this.mainTitle)}></div> : null}
           </div>
         </div>
       </div>

--- a/src/components/biggive-video/biggive-video.tsx
+++ b/src/components/biggive-video/biggive-video.tsx
@@ -23,7 +23,7 @@ export class BiggiveVideo {
   render() {
     return (
       <div class={'container space-above-' + this.spaceAbove + ' space-below-' + this.spaceBelow}>
-        <div class="video-wrap" innerHTML={VideoService.getEmbedHtml(this.videoUrl)}></div>
+        <div class="video-wrap" innerHTML={VideoService.getEmbedHtml(this.videoUrl, null)}></div>
       </div>
     );
   }

--- a/src/util/video.ts
+++ b/src/util/video.ts
@@ -1,9 +1,12 @@
 export class VideoService {
-  static getEmbedHtml(url: string) {
+  static getEmbedHtml(url: string, title: string | null) {
     if (url.match(/youtube\.com/g)) {
-      return '<iframe loading="lazy" src="' + url + '"></iframe>';
+      return `<iframe loading="lazy" src="${url}"></iframe>`;
+    } else if (url.match(/player\.vimeo\.com/g)) {
+      const titlePart = title !== null && title.length > 0 ? ` title="${title}"` : '';
+      return `<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="${url}?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;dnt=1" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;"${titlePart}></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>`;
     } else {
-      return '<video controls src=' + url + '></video>';
+      return `<video controls src="${url}"></video>`;
     }
   }
 }


### PR DESCRIPTION
…ies)

It's not really possible to avoid cookies when embedding Youtube videos, so Vimeo seems like a better option.

Demo in an uncommited change to components' index.html, passing "https://player.vimeo.com/video/860172535" as the video-url prop.

![image](https://github.com/thebiggive/components/assets/159481/9fd65260-5526-4d08-ac2e-21e03192710e)
