### PR TITLE
DON-783: Set focus on popup when opened

### DIFF
--- a/src/components/biggive-popup/biggive-popup.tsx
+++ b/src/components/biggive-popup/biggive-popup.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Method, h } from '@stencil/core';
+import { Component, Method, h } from '@stencil/core';
 
 @Component({
   tag: 'biggive-popup',
@@ -6,38 +6,28 @@ import { Component, Element, Method, h } from '@stencil/core';
   shadow: true,
 })
 export class BiggivePopup {
-  @Element() el: HTMLBiggivePopupElement;
+  private popup: HTMLDivElement;
 
   @Method()
   async openFromOutside() {
-    let popup = this.el.shadowRoot?.querySelector('.popup');
-    if (popup) {
-      popup.setAttribute('data-visible', 'true');
-    }
+    this.popup.focus();
+    this.popup.setAttribute('data-visible', 'true');
   }
 
   @Method()
   async closeFromOutside() {
-    let popup = this.el.shadowRoot?.querySelector('.popup');
-    if (popup) {
-      popup.setAttribute('data-visible', 'false');
-    }
+    this.popup.setAttribute('data-visible', 'false');
   }
 
   private closeFromWithin = (event: any) => {
-    let popup = this.el.shadowRoot?.querySelector('.popup');
-    if (!popup) {
-      return;
-    }
-
     if (event.target.classList.contains('popup') || event.target.classList.contains('close')) {
-      popup.setAttribute('data-visible', 'false');
+      this.popup.setAttribute('data-visible', 'false');
     }
   };
 
   render() {
     return (
-      <div class="popup" onClick={this.closeFromWithin}>
+      <div class="popup" ref={el => (this.popup = el as HTMLDivElement)} tabindex="0" onClick={this.closeFromWithin}>
         <div class="sleeve">
           <div class="header">
             <div class="close" onClick={this.closeFromWithin}></div>

--- a/src/components/biggive-popup/biggive-popup.tsx
+++ b/src/components/biggive-popup/biggive-popup.tsx
@@ -27,7 +27,7 @@ export class BiggivePopup {
 
   render() {
     return (
-      <div class="popup" ref={el => (this.popup = el as HTMLDivElement)} tabindex="0" onClick={this.closeFromWithin}>
+      <div class="popup" ref={el => (this.popup = el as HTMLDivElement)} tabindex="-1" onClick={this.closeFromWithin}>
         <div class="sleeve">
           <div class="header">
             <div class="close" onClick={this.closeFromWithin}></div>

--- a/src/components/biggive-popup/test/biggive-popup.spec.tsx
+++ b/src/components/biggive-popup/test/biggive-popup.spec.tsx
@@ -10,7 +10,7 @@ describe('biggive-popup', () => {
     expect(page.root).toEqualHtml(`
       <biggive-popup>
         <mock:shadow-root>
-          <div class="popup">
+          <div class="popup" tabindex="-1">
             <div class="sleeve">
               <div class="header">
                 <div class="close"></div>


### PR DESCRIPTION
Popup is currently used for selecting filters in the explore page, and is about to be used for selecting cookie preferences