### PR TITLE
INFRA-122 - use `getAssetPath()` as per readme

### DIFF
--- a/src/components/biggive-back-to-top/biggive-back-to-top.tsx
+++ b/src/components/biggive-back-to-top/biggive-back-to-top.tsx
@@ -10,7 +10,7 @@ export class BiggiveBackToTop {
     return (
       <div class="container">
         <a href="#">
-          <img src={getAssetPath('../assets/images/triangles-combined.svg')} />
+          <img src={getAssetPath('/assets/images/triangles-combined.svg')} />
           <span class="text">Back to top</span>
         </a>
       </div>

--- a/src/components/biggive-footer/biggive-footer.tsx
+++ b/src/components/biggive-footer/biggive-footer.tsx
@@ -72,7 +72,7 @@ export class BiggiveFooter {
 
           <div class="row row-bottom">
             <div class="postscript-wrap">
-              <img class="fr-logo" src={getAssetPath('../assets/images/fundraising-regulator.png')} alt="Fundraising Regulator" />
+              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Fundraising Regulator" />
 
               <nav class="nav nav-postscript" aria-label="Legal"></nav>
             </div>
@@ -193,7 +193,7 @@ export class BiggiveFooter {
 
           <div class="row row-bottom">
             <div class="postscript-wrap">
-              <img class="fr-logo" src={getAssetPath('../assets/images/fundraising-regulator.png')} alt="Fundraising Regulator" />
+              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Fundraising Regulator" />
 
               <nav class="nav nav-postscript" aria-label="Legal">
                 <ul slot="nav-postscript">


### PR DESCRIPTION
Hopefully fixes loading assets like the FR logo in footer in full `dist` load contexts like the "sorry" page