### PR TITLE
INFRA-122: Fix alt text for fundraising regulator footer image

### DIFF
--- a/src/components/biggive-footer/biggive-footer.tsx
+++ b/src/components/biggive-footer/biggive-footer.tsx
@@ -72,7 +72,7 @@ export class BiggiveFooter {
 
           <div class="row row-bottom">
             <div class="postscript-wrap">
-              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Fundraising Regulator" />
+              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Registered with FUNDRAISING REGULATOR" />
 
               <nav class="nav nav-postscript" aria-label="Legal"></nav>
             </div>
@@ -193,7 +193,7 @@ export class BiggiveFooter {
 
           <div class="row row-bottom">
             <div class="postscript-wrap">
-              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Fundraising Regulator" />
+              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Registered with FUNDRAISING REGULATOR" />
 
               <nav class="nav nav-postscript" aria-label="Legal">
                 <ul slot="nav-postscript">

--- a/src/components/biggive-footer/test/biggive-footer.spec.tsx
+++ b/src/components/biggive-footer/test/biggive-footer.spec.tsx
@@ -34,7 +34,7 @@ describe('biggive-footer', () => {
 
         <div class="row row-bottom">
           <div class="postscript-wrap">
-            <img class="fr-logo" src="/assets/images/fundraising-regulator.png" alt="Fundraising Regulator">
+            <img class="fr-logo" src="/assets/images/fundraising-regulator.png" alt="Registered with FUNDRAISING REGULATOR">
             <nav class="nav nav-postscript" aria-label="Legal"></nav>
           </div>
           <div class="social-icon-wrap">


### PR DESCRIPTION
Alt text now matches the text that's inside the image, omitting the actual FR logo.

Image can be seen at
https://raw.githubusercontent.com/thebiggive/components/main/src/assets/images/fundraising-regulator.png

Although in components merging to main doesn't release to production automatically for frontend or wordpress, it does actually release directly to production for the "sorry" page, which is what I'm most interested in here and doesn't have a build step and pulls from NPM in the browser. 