### PR TITLE
COM-50 – get the Angular component library module to bootstrap its own elements

### DIFF
--- a/angular/projects/components/src/lib/components.module.ts
+++ b/angular/projects/components/src/lib/components.module.ts
@@ -1,10 +1,19 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { DIRECTIVES } from './stencil-generated';
+
+import { defineCustomElements } from '@biggive/components/loader';
 
 @NgModule({
   imports: [CommonModule],
   declarations: [...DIRECTIVES],
   exports: [...DIRECTIVES],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => defineCustomElements,
+      multi: true,
+    },
+  ],
 })
 export class ComponentsModule { }

--- a/src/components/biggive-totalizer/biggive-totalizer.tsx
+++ b/src/components/biggive-totalizer/biggive-totalizer.tsx
@@ -102,13 +102,9 @@ export class BiggiveTotalizer {
     // Deep clone [all children of] the ticker items internal wrapper and append them, so the ticker can show items without
     // a blank break. Sleeve 2 and up will animate on delays per https://stackoverflow.com/a/45847760.
     setTimeout(() => {
-      tickerItemsInternalWrapper.childNodes.forEach((child: HTMLElement) => {
-        console.log('Child element for cloning: ', child);
-
-        sleeve2 && sleeve2.appendChild(child.cloneNode(true)); // Deep clone all items.
-        sleeve3 && sleeve3.appendChild(child.cloneNode(true));
-        sleeve4 && sleeve4.appendChild(child.cloneNode(true));
-      });
+      sleeve2 && sleeve2.appendChild(tickerItemsInternalWrapper.cloneNode(true));
+      sleeve3 && sleeve3.appendChild(tickerItemsInternalWrapper.cloneNode(true));
+      sleeve4 && sleeve4.appendChild(tickerItemsInternalWrapper.cloneNode(true));
     }, 800);
 
     setTimeout(() => {


### PR DESCRIPTION
Pretty much per the 'Ionic way' in the latest docs at https://stenciljs.com/docs/angular#registering-custom-elements

This seems to become necessary with as-documented paths and Stencil v4. (I did a proof of concept calling a similar fn in Donate itself first, and the principle seems to work.)