### PR TITLE
Fix fontawesom NPM registry details

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@fortawesome:registry=https://npm.fontawesome.com/
+@fontawesome:registry=https://npm.fontawesome.com/
 //npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}


### PR DESCRIPTION
Before making this change today I was constantly getting "code E401 npm ERR! Incorrect or missing password." when running npm install.

Not sure why we haven't needed to fix this before now.