### PR TITLE
DON-965: Link to cookies fragment in privacy statement

### DIFF
--- a/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
+++ b/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
@@ -132,7 +132,9 @@ export class BiggiveCookieBanner {
         </p>
 
         <p>
-          <a href={this.blogUriPrefix + '/privacy'}>Find out more in our Privacy Statement</a>
+          <a href={this.blogUriPrefix + '/privacy#cookies'} target="_blank">
+            Find out more in our Cookies Statement
+          </a>
         </p>
 
         <div class="button-group">


### PR DESCRIPTION
I think we need to add a matching #cookies id into the content at https://biggive.org/privacy/ before merging this.