### PR TITLE
DON-964: Add cookie links to footer and allow opening the cookie pref…

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -896,6 +896,10 @@ export namespace Components {
     }
     interface BiggivePopup {
         "closeFromOutside": () => Promise<void>;
+        /**
+          * Function to execute when the modal is closed, whether by the user or programmatically.
+         */
+        "modalClosedCallback": () => void;
         "openFromOutside": () => Promise<void>;
     }
     interface BiggiveProgressBar {
@@ -1271,6 +1275,7 @@ declare global {
         new (): HTMLBiggiveCategoryIconElement;
     };
     interface HTMLBiggiveCookieBannerElementEventMap {
+        "preferenceModalClosed": void;
         "cookieBannerAcceptAllSelected": void;
         "cookieBannerSavePreferencesSelected": { analyticsAndTesting: Boolean; thirdParty: boolean };
     }
@@ -2102,6 +2107,7 @@ declare namespace LocalJSX {
           * Indicates that the user has made a selection of cookies purpose to accept.  Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie.
          */
         "onCookieBannerSavePreferencesSelected"?: (event: BiggiveCookieBannerCustomEvent<{ analyticsAndTesting: Boolean; thirdParty: boolean }>) => void;
+        "onPreferenceModalClosed"?: (event: BiggiveCookieBannerCustomEvent<void>) => void;
     }
     interface BiggiveFooter {
         "blogUrlPrefix"?: string | undefined;
@@ -2493,6 +2499,10 @@ declare namespace LocalJSX {
         "spaceBelow"?: number;
     }
     interface BiggivePopup {
+        /**
+          * Function to execute when the modal is closed, whether by the user or programmatically.
+         */
+        "modalClosedCallback"?: () => void;
     }
     interface BiggiveProgressBar {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -507,10 +507,11 @@ export namespace Components {
         "blogUriPrefix": string;
     }
     interface BiggiveFooter {
+        "blogUrlPrefix": string | undefined;
         /**
           * URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props
          */
-        "blogUrlPrefix": string | undefined;
+        "donateUrlPrefix": string;
         "experienceUrlPrefix": string | undefined;
         "headingLevel": 1 | 2 | 3 | 4 | 5 | 6;
         /**
@@ -1130,10 +1131,6 @@ export interface BiggiveCookieBannerCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLBiggiveCookieBannerElement;
 }
-export interface BiggiveFooterCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLBiggiveFooterElement;
-}
 export interface BiggiveIconButtonCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLBiggiveIconButtonElement;
@@ -1291,18 +1288,7 @@ declare global {
         prototype: HTMLBiggiveCookieBannerElement;
         new (): HTMLBiggiveCookieBannerElement;
     };
-    interface HTMLBiggiveFooterElementEventMap {
-        "showCookiePreferenceCenterClicked": void;
-    }
     interface HTMLBiggiveFooterElement extends Components.BiggiveFooter, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLBiggiveFooterElementEventMap>(type: K, listener: (this: HTMLBiggiveFooterElement, ev: BiggiveFooterCustomEvent<HTMLBiggiveFooterElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLBiggiveFooterElementEventMap>(type: K, listener: (this: HTMLBiggiveFooterElement, ev: BiggiveFooterCustomEvent<HTMLBiggiveFooterElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLBiggiveFooterElement: {
         prototype: HTMLBiggiveFooterElement;
@@ -2118,16 +2104,13 @@ declare namespace LocalJSX {
         "onCookieBannerSavePreferencesSelected"?: (event: BiggiveCookieBannerCustomEvent<{ analyticsAndTesting: Boolean; thirdParty: boolean }>) => void;
     }
     interface BiggiveFooter {
+        "blogUrlPrefix"?: string | undefined;
         /**
           * URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props
          */
-        "blogUrlPrefix"?: string | undefined;
+        "donateUrlPrefix"?: string;
         "experienceUrlPrefix"?: string | undefined;
         "headingLevel"?: 1 | 2 | 3 | 4 | 5 | 6;
-        /**
-          * Indicates that the user has made a selection of cookies purpose to accept.  Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie.
-         */
-        "onShowCookiePreferenceCenterClicked"?: (event: BiggiveFooterCustomEvent<void>) => void;
         /**
           * Conditionally render footer menu: hard-coded (preset) when set to true, dynamic (slot-based) when set to false
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -500,6 +500,10 @@ export namespace Components {
         "url": string;
     }
     interface BiggiveCookieBanner {
+        /**
+          * If true the Preferences modal will be auto-opened - for use when the user has requested to edit their cookie preferences
+         */
+        "autoOpenPreferences": boolean;
         "blogUriPrefix": string;
     }
     interface BiggiveFooter {
@@ -1126,6 +1130,10 @@ export interface BiggiveCookieBannerCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLBiggiveCookieBannerElement;
 }
+export interface BiggiveFooterCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLBiggiveFooterElement;
+}
 export interface BiggiveIconButtonCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLBiggiveIconButtonElement;
@@ -1283,7 +1291,18 @@ declare global {
         prototype: HTMLBiggiveCookieBannerElement;
         new (): HTMLBiggiveCookieBannerElement;
     };
+    interface HTMLBiggiveFooterElementEventMap {
+        "showCookiePreferenceCenterClicked": void;
+    }
     interface HTMLBiggiveFooterElement extends Components.BiggiveFooter, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLBiggiveFooterElementEventMap>(type: K, listener: (this: HTMLBiggiveFooterElement, ev: BiggiveFooterCustomEvent<HTMLBiggiveFooterElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLBiggiveFooterElementEventMap>(type: K, listener: (this: HTMLBiggiveFooterElement, ev: BiggiveFooterCustomEvent<HTMLBiggiveFooterElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLBiggiveFooterElement: {
         prototype: HTMLBiggiveFooterElement;
@@ -2084,6 +2103,10 @@ declare namespace LocalJSX {
         "url"?: string;
     }
     interface BiggiveCookieBanner {
+        /**
+          * If true the Preferences modal will be auto-opened - for use when the user has requested to edit their cookie preferences
+         */
+        "autoOpenPreferences"?: boolean;
         "blogUriPrefix": string;
         /**
           * Indicates that the user accepts cookies for any purpose, without discrimination.
@@ -2101,6 +2124,10 @@ declare namespace LocalJSX {
         "blogUrlPrefix"?: string | undefined;
         "experienceUrlPrefix"?: string | undefined;
         "headingLevel"?: 1 | 2 | 3 | 4 | 5 | 6;
+        /**
+          * Indicates that the user has made a selection of cookies purpose to accept.  Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie.
+         */
+        "onShowCookiePreferenceCenterClicked"?: (event: BiggiveFooterCustomEvent<void>) => void;
         /**
           * Conditionally render footer menu: hard-coded (preset) when set to true, dynamic (slot-based) when set to false
          */

--- a/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
+++ b/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, h, Event, EventEmitter } from '@stencil/core';
+import { Component, Element, Prop, h, Event, EventEmitter, Watch } from '@stencil/core';
 
 @Component({
   tag: 'biggive-cookie-banner',
@@ -6,6 +6,11 @@ import { Component, Element, Prop, h, Event, EventEmitter } from '@stencil/core'
   shadow: true,
 })
 export class BiggiveCookieBanner {
+  /**
+   * If true the Preferences modal will be auto-opened - for use when the user has requested to edit their cookie
+   * preferences
+   */
+  @Prop() autoOpenPreferences: boolean = false;
   @Prop() blogUriPrefix!: string;
   @Element() el: HTMLBiggiveCookieBannerElement;
 
@@ -32,6 +37,17 @@ export class BiggiveCookieBanner {
     composed: true,
   })
   cookieBannerSavePreferencesSelected: EventEmitter<{ analyticsAndTesting: Boolean; thirdParty: boolean }>;
+
+  componentDidLoad() {
+    this.autoOpenPreferencesIfRequested();
+  }
+
+  @Watch('autoOpenPreferences')
+  private autoOpenPreferencesIfRequested() {
+    if (this.autoOpenPreferences) {
+      this.handleChoosePrefencesClick();
+    }
+  }
 
   private handleChoosePrefencesClick = () => {
     const elementById = this.el.shadowRoot?.getElementById('cookie-preferences-popup') as HTMLBiggivePopupElement;

--- a/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
+++ b/src/components/biggive-cookie-banner/biggive-cookie-banner.tsx
@@ -14,6 +14,14 @@ export class BiggiveCookieBanner {
   @Prop() blogUriPrefix!: string;
   @Element() el: HTMLBiggiveCookieBannerElement;
 
+  @Event({
+    eventName: 'preferenceModalClosed',
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  })
+  preferenceModalClosed: EventEmitter<void>;
+
   /**
    * Indicates that the user accepts cookies for any purpose, without discrimination.
    */
@@ -86,7 +94,7 @@ export class BiggiveCookieBanner {
   render() {
     return (
       <div class="cooke-consent-container">
-        <biggive-popup id="cookie-preferences-popup">
+        <biggive-popup id="cookie-preferences-popup" modal-closed-callback={this.preferenceModalClosed.emit}>
           <div class="content">
             <h4 class="space-above-0 space-below-3 text-colour-primary">Manage your cookie preferences</h4>
             <form>

--- a/src/components/biggive-cookie-banner/readme.md
+++ b/src/components/biggive-cookie-banner/readme.md
@@ -8,9 +8,10 @@ to making it work before we can add it to our website.
 
 ## Properties
 
-| Property                     | Attribute         | Description | Type     | Default     |
-| ---------------------------- | ----------------- | ----------- | -------- | ----------- |
-| `blogUriPrefix` _(required)_ | `blog-uri-prefix` |             | `string` | `undefined` |
+| Property                     | Attribute               | Description                                                                                                              | Type      | Default     |
+| ---------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------- | ----------- |
+| `autoOpenPreferences`        | `auto-open-preferences` | If true the Preferences modal will be auto-opened - for use when the user has requested to edit their cookie preferences | `boolean` | `false`     |
+| `blogUriPrefix` _(required)_ | `blog-uri-prefix`       |                                                                                                                          | `string`  | `undefined` |
 
 
 ## Events

--- a/src/components/biggive-cookie-banner/readme.md
+++ b/src/components/biggive-cookie-banner/readme.md
@@ -20,6 +20,7 @@ to making it work before we can add it to our website.
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `cookieBannerAcceptAllSelected`       | Indicates that the user accepts cookies for any purpose, without discrimination.                                                                                                                         | `CustomEvent<void>`                                                   |
 | `cookieBannerSavePreferencesSelected` | Indicates that the user has made a selection of cookies purpose to accept.  Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie. | `CustomEvent<{ analyticsAndTesting: Boolean; thirdParty: boolean; }>` |
+| `preferenceModalClosed`               |                                                                                                                                                                                                          | `CustomEvent<void>`                                                   |
 
 
 ## Dependencies

--- a/src/components/biggive-footer/biggive-footer.tsx
+++ b/src/components/biggive-footer/biggive-footer.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, getAssetPath, h, Prop } from '@stencil/core';
+import { Component, Element, getAssetPath, h, Prop } from '@stencil/core';
 import { makeURL } from '../../util/helper-methods';
 
 @Component({
@@ -15,6 +15,7 @@ export class BiggiveFooter {
    * URL prefixes vary by environment, and components library is not best placed to know what they are, so we
    * take them as props
    */
+  @Prop() donateUrlPrefix: string;
   @Prop() blogUrlPrefix: string | undefined;
   @Prop() experienceUrlPrefix: string | undefined;
 
@@ -23,19 +24,6 @@ export class BiggiveFooter {
    * hard-coded (preset) when set to true, dynamic (slot-based) when set to false
    */
   @Prop() usePresetFooter = false;
-
-  /**
-   * Indicates that the user has made a selection of cookies purpose to accept.
-   *
-   * Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie.
-   */
-  @Event({
-    eventName: 'showCookiePreferenceCenterClicked',
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-  })
-  showCookiePreferenceCenterClicked: EventEmitter<void>;
 
   private appendMenu(menuName: string) {
     var node = this.host.querySelector(`[slot="${menuName}"]`);
@@ -52,10 +40,6 @@ export class BiggiveFooter {
       this.appendMenu('nav-postscript');
     }
   }
-
-  private emitShowCookiePreferences = () => {
-    this.showCookiePreferenceCenterClicked.emit();
-  };
 
   render() {
     const HeadingTag = `h${this.headingLevel}`;
@@ -224,9 +208,7 @@ export class BiggiveFooter {
                     <a href={makeURL('Blog', this.blogUrlPrefix, 'privacy#cookies')}>Cookies Statement</a>
                   </li>
                   <li>
-                    <a href="javascript:void(0);" onClick={this.emitShowCookiePreferences}>
-                      Cookies Preference Centre
-                    </a>
+                    <a href={makeURL('Donate', this.donateUrlPrefix, 'cookie-preferences')}>Cookies Preference Centre</a>
                   </li>
                 </ul>
               </nav>

--- a/src/components/biggive-footer/biggive-footer.tsx
+++ b/src/components/biggive-footer/biggive-footer.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, getAssetPath, h, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, getAssetPath, h, Prop } from '@stencil/core';
 import { makeURL } from '../../util/helper-methods';
 
 @Component({
@@ -24,6 +24,19 @@ export class BiggiveFooter {
    */
   @Prop() usePresetFooter = false;
 
+  /**
+   * Indicates that the user has made a selection of cookies purpose to accept.
+   *
+   * Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie.
+   */
+  @Event({
+    eventName: 'showCookiePreferenceCenterClicked',
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  })
+  showCookiePreferenceCenterClicked: EventEmitter<void>;
+
   private appendMenu(menuName: string) {
     var node = this.host.querySelector(`[slot="${menuName}"]`);
     if (node !== null) {
@@ -39,6 +52,10 @@ export class BiggiveFooter {
       this.appendMenu('nav-postscript');
     }
   }
+
+  private emitShowCookiePreferences = () => {
+    this.showCookiePreferenceCenterClicked.emit();
+  };
 
   render() {
     const HeadingTag = `h${this.headingLevel}`;
@@ -202,6 +219,14 @@ export class BiggiveFooter {
                   </li>
                   <li>
                     <a href={makeURL('Blog', this.blogUrlPrefix, 'privacy')}>Privacy Statement</a>
+                  </li>
+                  <li>
+                    <a href={makeURL('Blog', this.blogUrlPrefix, 'privacy#cookies')}>Cookies Statement</a>
+                  </li>
+                  <li>
+                    <a href="javascript:void(0);" onClick={this.emitShowCookiePreferences}>
+                      Cookies Preference Centre
+                    </a>
                   </li>
                 </ul>
               </nav>

--- a/src/components/biggive-footer/readme.md
+++ b/src/components/biggive-footer/readme.md
@@ -15,6 +15,13 @@
 | `usePresetFooter`     | `use-preset-footer`     | Conditionally render footer menu: hard-coded (preset) when set to true, dynamic (slot-based) when set to false              | `boolean`                    | `false`     |
 
 
+## Events
+
+| Event                               | Description                                                                                                                                                                                              | Type                |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `showCookiePreferenceCenterClicked` | Indicates that the user has made a selection of cookies purpose to accept.  Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie. | `CustomEvent<void>` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/src/components/biggive-footer/readme.md
+++ b/src/components/biggive-footer/readme.md
@@ -9,17 +9,11 @@
 
 | Property              | Attribute               | Description                                                                                                                 | Type                         | Default     |
 | --------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------- |
-| `blogUrlPrefix`       | `blog-url-prefix`       | URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props | `string \| undefined`        | `undefined` |
+| `blogUrlPrefix`       | `blog-url-prefix`       |                                                                                                                             | `string \| undefined`        | `undefined` |
+| `donateUrlPrefix`     | `donate-url-prefix`     | URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props | `string`                     | `undefined` |
 | `experienceUrlPrefix` | `experience-url-prefix` |                                                                                                                             | `string \| undefined`        | `undefined` |
 | `headingLevel`        | `heading-level`         |                                                                                                                             | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | `5`         |
 | `usePresetFooter`     | `use-preset-footer`     | Conditionally render footer menu: hard-coded (preset) when set to true, dynamic (slot-based) when set to false              | `boolean`                    | `false`     |
-
-
-## Events
-
-| Event                               | Description                                                                                                                                                                                              | Type                |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `showCookiePreferenceCenterClicked` | Indicates that the user has made a selection of cookies purpose to accept.  Event data is an object with boolean properties to say whether the user accepts or refuses each category of optional cookie. | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/src/components/biggive-popup/biggive-popup.tsx
+++ b/src/components/biggive-popup/biggive-popup.tsx
@@ -1,4 +1,4 @@
-import { Component, Method, h } from '@stencil/core';
+import { Component, Method, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'biggive-popup',
@@ -7,6 +7,11 @@ import { Component, Method, h } from '@stencil/core';
 })
 export class BiggivePopup {
   private popup: HTMLDivElement;
+
+  /**
+   * Function to execute when the modal is closed, whether by the user or programmatically.
+   */
+  @Prop() modalClosedCallback: () => void = () => {};
 
   @Method()
   async openFromOutside() {
@@ -19,12 +24,14 @@ export class BiggivePopup {
   async closeFromOutside() {
     this.popup.setAttribute('data-visible', 'false');
     this.popup.setAttribute('tabindex', '-1');
+    this.modalClosedCallback();
   }
 
   private closeFromWithin = (event: any) => {
     if (event.target.classList.contains('popup') || event.target.classList.contains('close')) {
       this.popup.setAttribute('data-visible', 'false');
       this.popup.setAttribute('tabindex', '-1');
+      this.modalClosedCallback();
     }
   };
 

--- a/src/components/biggive-popup/readme.md
+++ b/src/components/biggive-popup/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property              | Attribute | Description                                                                            | Type         | Default    |
+| --------------------- | --------- | -------------------------------------------------------------------------------------- | ------------ | ---------- |
+| `modalClosedCallback` | --        | Function to execute when the modal is closed, whether by the user or programmatically. | `() => void` | `() => {}` |
+
+
 ## Methods
 
 ### `closeFromOutside() => Promise<void>`

--- a/src/index.html
+++ b/src/index.html
@@ -1183,6 +1183,7 @@
     <biggive-footer
       heading-level=3
       use-preset-footer="true"
+      donate-url-prefix="http://localhost:4200"
       blog-url-prefix="http://localhost:30003"
       experience-url-prefix="https://www.thebiggive.org.uk"
       ></biggive-footer>


### PR DESCRIPTION
…erence center programatically

This is a BC break, frontend must have a cookie preference center page working at /cookie-preferences when this is pulled into FE and/or WP.

Also needs to wait for https://github.com/thebiggive/wordpress/pull/175 as does #481 