### PR TITLE
DON-970: Fix handling of order by prop with unexpected casing

### DIFF
--- a/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
+++ b/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
@@ -3,7 +3,7 @@ import { faMagnifyingGlass } from '@fortawesome/pro-solid-svg-icons';
 
 const sortOptionLabels = {
   relevance: 'Relevance',
-  amountRaised: 'Most Raised',
+  amountRaised: 'Most raised',
   matchFundsRemaining: 'Match funds remaining',
 } as const;
 
@@ -463,18 +463,22 @@ export class BiggiveCampaignCardFilterGrid {
     );
   }
 
-  private getSelectedValue(): undefined | string {
-    if (this.selectedSortByOption === undefined) {
+  // I'm not sure if I understand the reasoning for own-methods-must-be-private. I made the method below public to unit
+  // test it. Maybe the idea is that we should move anything with enough logic to test outside the component class? I
+  // can do that if people think it's better.
+  //
+  // eslint-disable-next-line @stencil-community/own-methods-must-be-private
+  public getSelectedValue(): undefined | string {
+    const sortByOption = this.selectedSortByOption;
+    if (sortByOption === undefined) {
       return undefined;
     }
     const sortOptions = this.getSortOptions();
-    const selected = sortOptions.filter(option => option.label === this.selectedSortByOption)[0];
+    const selected = sortOptions.filter(option => {
+      return option.label.toLowerCase() === sortByOption.toLowerCase();
+    })[0];
 
-    if (selected === undefined) {
-      throw new Error(`Unexpected sort option "${this.selectedSortByOption}" selected`);
-    }
-
-    return selected.value;
+    return selected?.value;
   }
 
   private getSortOptions(): {

--- a/src/components/biggive-campaign-card-filter-grid/test/biggive-campaign-card-filter-grid.spec.tsx
+++ b/src/components/biggive-campaign-card-filter-grid/test/biggive-campaign-card-filter-grid.spec.tsx
@@ -2,6 +2,28 @@ import { newSpecPage } from '@stencil/core/testing';
 import { BiggiveCampaignCardFilterGrid } from '../biggive-campaign-card-filter-grid';
 
 describe('biggive-campaign-card-filter-grid', () => {
+  it.each([
+    ['Most raised', 'amountRaised'],
+    // client library may pass in term with casing we didn't expect, but we don't have type checking between there and here
+    // so passing it in with a different type to simulate that:
+    ['Most Raised' as 'Most raised', 'amountRaised'],
+    ['Relevance', undefined], // can not sort by Relevance unless we have a search term.
+    ['Match funds remaining', 'matchFundsRemaining'],
+  ] as const)('Gets the selected sort order value', (selectedSortByOption, expectedSortByValue) => {
+    const sut = new BiggiveCampaignCardFilterGrid();
+
+    sut.selectedSortByOption = selectedSortByOption;
+    expect(sut.getSelectedValue()).toBe(expectedSortByValue);
+  });
+
+  it('Gets relevance as a selected sort order value if there is a search term', () => {
+    const sut = new BiggiveCampaignCardFilterGrid();
+
+    sut.searchText = 'Atlantis';
+    sut.selectedSortByOption = 'Relevance';
+    expect(sut.getSelectedValue()).toBe('relevance');
+  });
+
   it('renders with no search term', async () => {
     // Should show just 2 sort options, not Relevance.
     const page = await newSpecPage({


### PR DESCRIPTION
Currently FE is passing Most Raised with two capitals but the component is only expecting one capital. Hard to be sure ot always get this matched up properly so doing a case insenstive comparison here

Should fix this error: 

![image](https://github.com/thebiggive/components/assets/159481/6f21bf45-ca86-40ab-b794-0909d02332cd)
