### PR TITLE
Revert "Bump the all-dependencies group across 1 directory with 11 updates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "jest-cli": "^29.7.0",
         "lint-staged": "^15.2.0",
         "prettier": "^3.1.1",
-        "puppeteer": "22.12.*",
+        "puppeteer": "22.11.*",
         "storybook": "^8.1.6"
       }
     },
@@ -3728,19 +3728,25 @@
       "dev": true
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
-      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
-      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3749,13 +3755,16 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
-      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3764,31 +3773,32 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
-      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
-        "@radix-ui/react-focus-scope": "1.1.0",
-        "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-slot": "1.1.0",
-        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "2.5.5"
       },
       "peerDependencies": {
         "@types/react": "*",
         "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3800,22 +3810,23 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
-      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-use-callback-ref": "1.1.0",
-        "@radix-ui/react-use-escape-keydown": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",
         "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3827,13 +3838,16 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
-      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
       "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3842,20 +3856,21 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
-      "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+      "integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-use-callback-ref": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
         "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3867,16 +3882,17 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
-      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3885,19 +3901,19 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
-      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-use-layout-effect": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",
         "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3909,19 +3925,20 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
-      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
         "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3933,18 +3950,19 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
-      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-slot": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
         "@types/react": "*",
         "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3956,16 +3974,17 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
-      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3974,13 +3993,16 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
-      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3989,16 +4011,17 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
-      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4007,16 +4030,17 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
-      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
       "dev": true,
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.0"
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4025,13 +4049,16 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
-      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
       "peerDependencies": {
         "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4106,9 +4133,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
-      "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg==",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -4131,12 +4158,12 @@
       }
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.1.11.tgz",
-      "integrity": "sha512-jqYXgBgOVInStOCk//AA+dGkrfN8R7rDXA4lyu82zM59kvICtG9iqgmkSRDn0Z3zUkM+lIHZGoz0aLVQ8pxsgw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.1.8.tgz",
+      "integrity": "sha512-bDfeoU+rkrvEXR8MUYqqTDOHIKjcuC44JAqKbj0yBVeh2haJF66rBiTPYO/AD9JcBTCA95S9ya3j08cy9+g5lw==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-events": "8.1.11",
+        "@storybook/core-events": "8.1.8",
         "@storybook/global": "^5.0.0",
         "@types/uuid": "^9.0.1",
         "dequal": "^2.0.2",
@@ -4149,9 +4176,9 @@
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.1.11.tgz",
-      "integrity": "sha512-naGf1ovmsU2pSWb270yRO1IidnO+0YCZ5Tcb8I4rPhZ0vsdXNURYKS1LPSk1OZkvaUXdeB4Im9HhHfUBJOW9oQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.1.8.tgz",
+      "integrity": "sha512-HEHvJHyLdR/iLg53ynKp+EqHDMbLnCZr2yaxdUUyQ2p5M5kg+VXe75+H34H0AYW7uTQniHghfVUgXuHKY9z4Jg==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -4164,12 +4191,12 @@
       }
     },
     "node_modules/@storybook/addon-controls": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.1.11.tgz",
-      "integrity": "sha512-q/Vt4meNVlFlBWIMCJhx6r+bqiiYocCta2RoUK5nyIZUiLzHncKHX6JnCU36EmJzRyah9zkwjfCb2G1r9cjnoQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.1.8.tgz",
+      "integrity": "sha512-o/0WUSlWd6Erf37D9xOnRk7GYMOYf0eI1O7MQdPBSOpI+I77684vCp35D/WcamK3lqz0sAewF5tM14tuo3ATZw==",
       "dev": true,
       "dependencies": {
-        "@storybook/blocks": "8.1.11",
+        "@storybook/blocks": "8.1.8",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
         "ts-dedent": "^2.0.0"
@@ -4180,24 +4207,24 @@
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.1.11.tgz",
-      "integrity": "sha512-69dv+CE4R5wFU7xnJmhuyEbLN2PEVDV3N/BbgJqeucIYPmm6zDV83Q66teCHKYtRln3BFUqPH5mxsjiHobxfJQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.1.8.tgz",
+      "integrity": "sha512-zTQxrO53TxDNUn/laK4BCBHp1nO2DABq4BIuNAapYq+DuQ3w981/Jcb9Qwr8TrGGb0hmT1vV2ZGP1m0KfA8OQg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@mdx-js/react": "^3.0.0",
-        "@storybook/blocks": "8.1.11",
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/components": "8.1.11",
-        "@storybook/csf-plugin": "8.1.11",
-        "@storybook/csf-tools": "8.1.11",
+        "@storybook/blocks": "8.1.8",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/components": "8.1.8",
+        "@storybook/csf-plugin": "8.1.8",
+        "@storybook/csf-tools": "8.1.8",
         "@storybook/global": "^5.0.0",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
-        "@storybook/react-dom-shim": "8.1.11",
-        "@storybook/theming": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
+        "@storybook/react-dom-shim": "8.1.8",
+        "@storybook/theming": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "fs-extra": "^11.1.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -4212,24 +4239,24 @@
       }
     },
     "node_modules/@storybook/addon-essentials": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.1.11.tgz",
-      "integrity": "sha512-uRTpcIZQnflML8H+2onicUNIIssKfuviW8Lyrs/KFwSZ1rMcYzhwzCNbGlIbAv04tgHe5NqEyNhb+DVQcZQBzg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.1.8.tgz",
+      "integrity": "sha512-qAVuighthkhYEgM977vj3sk4mZEOP+JGt+qYLT4nIjuucNm9aXyUOQovIiLQeAwtj+zvwSJ7diFDlQW3eYq+hQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/addon-actions": "8.1.11",
-        "@storybook/addon-backgrounds": "8.1.11",
-        "@storybook/addon-controls": "8.1.11",
-        "@storybook/addon-docs": "8.1.11",
-        "@storybook/addon-highlight": "8.1.11",
-        "@storybook/addon-measure": "8.1.11",
-        "@storybook/addon-outline": "8.1.11",
-        "@storybook/addon-toolbars": "8.1.11",
-        "@storybook/addon-viewport": "8.1.11",
-        "@storybook/core-common": "8.1.11",
-        "@storybook/manager-api": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
+        "@storybook/addon-actions": "8.1.8",
+        "@storybook/addon-backgrounds": "8.1.8",
+        "@storybook/addon-controls": "8.1.8",
+        "@storybook/addon-docs": "8.1.8",
+        "@storybook/addon-highlight": "8.1.8",
+        "@storybook/addon-measure": "8.1.8",
+        "@storybook/addon-outline": "8.1.8",
+        "@storybook/addon-toolbars": "8.1.8",
+        "@storybook/addon-viewport": "8.1.8",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/manager-api": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -4238,9 +4265,9 @@
       }
     },
     "node_modules/@storybook/addon-highlight": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.1.11.tgz",
-      "integrity": "sha512-Iu8FCAd4ETsB6QF4xDE/OLLZY3HOFopuLM5KE0f58jnccF5zAVGr1Rj/54p6TeK0PEou0tLRPFuZs+LPlEzrSw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.1.8.tgz",
+      "integrity": "sha512-5xT0+F2TqLyS2Jg6pEpCgonFLpWypNufUPN5v4Sne2pTrmGSUu6Jse7j856eNlMcoULOrB81wWi0oZ7DH6Hyyw==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -4251,15 +4278,15 @@
       }
     },
     "node_modules/@storybook/addon-interactions": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.1.11.tgz",
-      "integrity": "sha512-nkc01z61mYM1kxf0ncBQLlFnnwW4RAVPfRSxK9BdbFN3AAvFiHCwVZdn71mi+C3L8oTqYR6o32e0RlXk+AjhHA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.1.8.tgz",
+      "integrity": "sha512-mHKEzKfhOJXtV+D4qLMzufi0UnEfjcTzI0TrXGhqA8FDMjX+OZEVkNudKk43NkJLU+dDjtthvdvYu8j4kMibuQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "8.1.11",
-        "@storybook/test": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/instrumenter": "8.1.8",
+        "@storybook/test": "8.1.8",
+        "@storybook/types": "8.1.8",
         "polished": "^4.2.2",
         "ts-dedent": "^2.2.0"
       },
@@ -4269,9 +4296,9 @@
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-8.1.11.tgz",
-      "integrity": "sha512-HlV2RQSrZyi+55W1B1a9eWNuJdNpWx0g3j7s2arNlNmbd6/kfWAp84axBstI1tL0nW4svut7bWlCsMSOIden+A==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-8.1.8.tgz",
+      "integrity": "sha512-R6pRpsIWw06v21KdUjCxGZ8664hPtCSEGNhK1dqk9EbSXOpc24iX3cn39EqxQ4OEo/laAfozNJQkzD+/dIL6kw==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.7",
@@ -4292,9 +4319,9 @@
       }
     },
     "node_modules/@storybook/addon-measure": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.1.11.tgz",
-      "integrity": "sha512-LkQD3SiLWaWt53aLB3EnmhD9Im8EOO+HKSUE+XGnIJRUcHHRqHfvDkN9KX7T1DCWbfRE5WzMHF5o23b3UiAANw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.1.8.tgz",
+      "integrity": "sha512-slmzrMEQVY+K+3XNRs+JajLTVOMuIWBhdT1LqEI9HT2MH8ng5hutLYWW02df6QuwsEtLn03QmT2RLokgPxshyw==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -4306,9 +4333,9 @@
       }
     },
     "node_modules/@storybook/addon-outline": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.1.11.tgz",
-      "integrity": "sha512-vco3RLVjkcS25dNtj1lxmjq4fC0Nq08KNLMS5cbNPVJWNTuSUi/2EthSTQQCdpfMV/p6u+D5uF20A9Pl0xJFXw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.1.8.tgz",
+      "integrity": "sha512-hj2hNXMdfwZcUINftviwyl2c6k1kKwe+HgXYI1aUbaPvyj7K86CujYr9WlOUQITp7oTDE8+8/yZe0Xq2MEO/mA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -4320,9 +4347,9 @@
       }
     },
     "node_modules/@storybook/addon-toolbars": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.1.11.tgz",
-      "integrity": "sha512-reIKB0+JTiP+GNzynlDcRf4xmv9+j/DQ94qiXl2ZG5+ufKilH8DiRZpVA/i0x+4+TxdGdOJr1/pOf8tAmhNEoQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.1.8.tgz",
+      "integrity": "sha512-E3h7h/fbis+9PfIJLKRA8ZRwD/o21PRwuvkOWjX0H+7bgVZKkj0ndT0wBvyMRDY9bDoiUIUrc5biA0g3vMbdSw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4330,9 +4357,9 @@
       }
     },
     "node_modules/@storybook/addon-viewport": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.1.11.tgz",
-      "integrity": "sha512-qk4IcGnAgiAUQxt8l5PIQ293Za+w6wxlJQIpxr7+QM8OVkADPzXY0MmQfYWU9EQplrxAC2MSx3/C1gZeq+MDOQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.1.8.tgz",
+      "integrity": "sha512-npYqLSpduRvIQ51VJuKvWo2xKPQ1i2WF6p0SgGXqfhoX+c0NColAQC/5VcSdbfFMkx5hH6ikeOmEJqkB2myFCQ==",
       "dev": true,
       "dependencies": {
         "memoizerific": "^1.11.3"
@@ -4343,9 +4370,9 @@
       }
     },
     "node_modules/@storybook/addon-webpack5-compiler-swc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-webpack5-compiler-swc/-/addon-webpack5-compiler-swc-1.0.4.tgz",
-      "integrity": "sha512-S/ypdAK9oqwUAt3ZOn44qi3RWdH5uBLbBgtfHSXckqTpQRu7F7A9bRzjK+H5ti4xVADRhxu/xzIBwxWgcCeIXA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-webpack5-compiler-swc/-/addon-webpack5-compiler-swc-1.0.3.tgz",
+      "integrity": "sha512-ahemZdpFN7Ikz2WTy0sLJ38t6OWLLKweeTNOfUh2ARd3x0CqJxAqWLBAFXJke+2KDFUQg9MTE+1rwHEFCPYUvQ==",
       "dev": true,
       "dependencies": {
         "@swc/core": "1.5.7",
@@ -4356,23 +4383,23 @@
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.1.11.tgz",
-      "integrity": "sha512-eMed7PpL/hAVM6tBS7h70bEAyzbiSU9I/kye4jZ7DkCbAsrX6OKmC7pcHSDn712WTcf3vVqxy5jOKUmOXpc0eg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.1.8.tgz",
+      "integrity": "sha512-nx18ism4YCuLFOmI6mQ+EJD1XABcbDdAyeheZPwkwB+fKkseNiOy7C/Mqio7ReYIncvlML6CCUyFm/OSEZkHkQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.11",
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/components": "8.1.11",
-        "@storybook/core-events": "8.1.11",
+        "@storybook/channels": "8.1.8",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/components": "8.1.8",
+        "@storybook/core-events": "8.1.8",
         "@storybook/csf": "^0.1.7",
-        "@storybook/docs-tools": "8.1.11",
+        "@storybook/docs-tools": "8.1.8",
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^1.2.5",
-        "@storybook/manager-api": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
-        "@storybook/theming": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/manager-api": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
+        "@storybook/theming": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/lodash": "^4.14.167",
         "color-convert": "^2.0.1",
         "dequal": "^2.0.2",
@@ -4404,15 +4431,15 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.1.11.tgz",
-      "integrity": "sha512-U7bmed4Ayg+OlJ8HPmLeGxLTHzDY7rxmxM4aAs4YL01fufYfBcjkIP9kFhJm+GJOvGm+YJEUAPe5mbM1P/bn0Q==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.1.8.tgz",
+      "integrity": "sha512-M4qpETmQNUTg6KEt4nVONjF2dXlVV1V+Mxf9saiinoj+PCyHdz+BmYYmiGtopUPxJ2YGvTL1nGykkyH57HutrQ==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "8.1.11",
-        "@storybook/manager": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/manager": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
         "@types/ejs": "^3.1.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
         "browser-assert": "^1.2.1",
@@ -4430,19 +4457,19 @@
       }
     },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.1.11.tgz",
-      "integrity": "sha512-3/aKmnZu+mHj5LB4VyvzrlHzn2iVjH5y8EUPtFYOkjc2KBkPpF39jBHecfDVCWeO/6kgvAI41t7LLnYB6DZqhw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.1.8.tgz",
+      "integrity": "sha512-L02ZG8583WqAhcW8+gKVKO99kb8ThhwSKMmtCk9XR++CCpO7kgR0N/lGJr79f2OYFuM6WQhfO/FRtER/7o45lw==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.11",
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-common": "8.1.11",
-        "@storybook/core-events": "8.1.11",
-        "@storybook/core-webpack": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/preview": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
+        "@storybook/channels": "8.1.8",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/core-events": "8.1.8",
+        "@storybook/core-webpack": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/preview": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
         "@types/node": "^18.0.0",
         "@types/semver": "^7.3.4",
         "browser-assert": "^1.2.1",
@@ -4493,13 +4520,13 @@
       }
     },
     "node_modules/@storybook/channels": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.11.tgz",
-      "integrity": "sha512-fu5FTqo6duOqtJFa6gFzKbiSLJoia+8Tibn3xFfB6BeifWrH81hc+AZq0lTmHo5qax2G5t8ZN8JooHjMw6k2RA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.8.tgz",
+      "integrity": "sha512-mEjg72jmB7hBSDUIpSzQL+MC61kUn4D9CCH1EK5K6Cfr1dmmHaCyDPCtBXSvuVSKn1VbF3JfT429v+iYeBrHlA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-events": "8.1.11",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-events": "8.1.8",
         "@storybook/global": "^5.0.0",
         "telejson": "^7.2.0",
         "tiny-invariant": "^1.3.1"
@@ -4510,22 +4537,22 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.1.11.tgz",
-      "integrity": "sha512-4U48w9C7mVEKrykcPcfHwJkRyCqJ28XipbElACbjIIkQEqaHaOVtP3GeKIrgkoOXe/HK3O4zKWRP2SqlVS0r4A==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.1.8.tgz",
+      "integrity": "sha512-GrU8zcLK0l/Jo9xQ42iEBqF0YL83gZF/GDTV+9MVMU1JtBtFldomvyGzT9J3TwvPgzC+rCmlk16rY1M2vc5klg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/types": "^7.24.0",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "8.1.11",
-        "@storybook/core-common": "8.1.11",
-        "@storybook/core-events": "8.1.11",
-        "@storybook/core-server": "8.1.11",
-        "@storybook/csf-tools": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/telemetry": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/codemod": "8.1.8",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/core-events": "8.1.8",
+        "@storybook/core-server": "8.1.8",
+        "@storybook/csf-tools": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/telemetry": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -4679,9 +4706,9 @@
       }
     },
     "node_modules/@storybook/client-logger": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.11.tgz",
-      "integrity": "sha512-DVMh2usz3yYmlqCLCiCKy5fT8/UR9aTh+gSqwyNFkGZrIM4otC5A8eMXajXifzotQLT5SaOEnM3WzHwmpvMIEA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.8.tgz",
+      "integrity": "sha512-VABFR6jHtORRuRcm+q49T0F3z6LY46+qjkvETafMIy3jcXnLTKubaLVMZBxUyYbh6H4RYv8YjnkYcrUszgZCEQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -4692,18 +4719,18 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.1.11.tgz",
-      "integrity": "sha512-/LCozjH1IQ1TOs9UQV59BE0X6UZ9q+C0NEUz7qmJZPrwAii3FkW4l7D/fwxblpMExaoxv0oE8NQfUz49U/5Ymg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.1.8.tgz",
+      "integrity": "sha512-hW9kQTgYN7GjLzjG624Bym1SfWfxQrHE2snIgbwRD9mO+jc/J6qjrR7Z42hV60LypqZ/FcZvBRq/1F247tNq9g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@babel/types": "^7.24.0",
         "@storybook/csf": "^0.1.7",
-        "@storybook/csf-tools": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/csf-tools": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
         "globby": "^14.0.1",
@@ -4763,19 +4790,19 @@
       }
     },
     "node_modules/@storybook/components": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.1.11.tgz",
-      "integrity": "sha512-iXKsNu7VmrLBtjMfPj7S4yJ6T13GU6joKcVcrcw8wfrQJGlPFp4YaURPBUEDxvCt1XWi5JkaqJBvb48kIrROEQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.1.8.tgz",
+      "integrity": "sha512-DEfAtDEeISkic8jFm/rFQeVGdA0evVkbiOof+insJxzh6KnIfnZVmJysX02xoUhOCIMjo59c7x0nmUf7NlYsMw==",
       "dev": true,
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
-        "@storybook/client-logger": "8.1.11",
+        "@storybook/client-logger": "8.1.8",
         "@storybook/csf": "^0.1.7",
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^1.2.5",
-        "@storybook/theming": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/theming": "8.1.8",
+        "@storybook/types": "8.1.8",
         "memoizerific": "^1.11.3",
         "util-deprecate": "^1.0.2"
       },
@@ -4789,15 +4816,15 @@
       }
     },
     "node_modules/@storybook/core-common": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.11.tgz",
-      "integrity": "sha512-Ix0nplD4I4DrV2t9B+62jaw1baKES9UbR/Jz9LVKFF9nsua3ON0aVe73dOjMxFWBngpzBYWe+zYBTZ7aQtDH4Q==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.8.tgz",
+      "integrity": "sha512-RcJUTGjvVCuGtz7GifY8sMHLUvmsg8moDOgwwkOJ+9QdgInyuZeqLzNI7BjOv2CYCK1sy7x0eU7B4CWD8LwnwA==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-events": "8.1.11",
-        "@storybook/csf-tools": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/core-events": "8.1.8",
+        "@storybook/csf-tools": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
         "chalk": "^4.1.0",
@@ -4902,9 +4929,9 @@
       }
     },
     "node_modules/@storybook/core-events": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.11.tgz",
-      "integrity": "sha512-vXaNe2KEW9BGlLrg0lzmf5cJ0xt+suPjWmEODH5JqBbrdZ67X6ApA2nb6WcxDQhykesWCuFN5gp1l+JuDOBi7A==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.8.tgz",
+      "integrity": "sha512-ZJWPeqBLFKRlRN1MitYNEXpNL+7vACXy14d6ja3zYW39htSSPlQYI1RXMURk+qTvGfxy1ZlAeyN62WeYXhTqLA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.7",
@@ -4916,29 +4943,29 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.1.11.tgz",
-      "integrity": "sha512-L6dzQTmR0np/kagNONvvlm6lSvF1FNc9js3vxsEEPnEypLbhx8bDZaHmuhmBpYUzKyUMpRVQTE/WgjHLuBBuxA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.1.8.tgz",
+      "integrity": "sha512-v2V7FC/y/lrKPxcseIwPavjdCCDHphpj+A23Jmp822tqYn+I4nYRvE74QKyn5dfLrdn52nz8KrUFwjhuacj10Q==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.126",
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "8.1.11",
-        "@storybook/channels": "8.1.11",
-        "@storybook/core-common": "8.1.11",
-        "@storybook/core-events": "8.1.11",
+        "@storybook/builder-manager": "8.1.8",
+        "@storybook/channels": "8.1.8",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/core-events": "8.1.8",
         "@storybook/csf": "^0.1.7",
-        "@storybook/csf-tools": "8.1.11",
+        "@storybook/csf-tools": "8.1.8",
         "@storybook/docs-mdx": "3.1.0-next.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "8.1.11",
-        "@storybook/manager-api": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
-        "@storybook/telemetry": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/manager": "8.1.8",
+        "@storybook/manager-api": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
+        "@storybook/telemetry": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/detect-port": "^1.3.0",
         "@types/diff": "^5.0.9",
         "@types/node": "^18.0.0",
@@ -5081,14 +5108,14 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.1.11.tgz",
-      "integrity": "sha512-UQY+t0BDb408OuxW6jQN1ghXcejZlFNgprgvuKlhY3MSv1XwmjrxBDwnLDat4QfBJHFbjdn4eR7pSBzrfE6tKA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.1.8.tgz",
+      "integrity": "sha512-rT0Nn72Z6tDLM4EX9SWUmRtIWGxve/u1MBwckBuztzeQaGUl4ORMDtbo4Ahvfc1oEapHKmow+zvzeH0NWGCw5w==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-common": "8.1.11",
-        "@storybook/node-logger": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/node-logger": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/node": "^18.0.0",
         "ts-dedent": "^2.0.0"
       },
@@ -5107,12 +5134,12 @@
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.1.11.tgz",
-      "integrity": "sha512-hkA8gjFtSN/tabG0cuvmEqanMXtxPr3qTkp4UNSt1R6jBEgFHRG2y/KYLl367kDwOSFTT987ZgRfJJruU66Fvw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.1.8.tgz",
+      "integrity": "sha512-5OxJlbedziDFdIGefPGSptEbfdGfuW9CViv9+eQ3g4AwG8HLdtSrcJtxYuUsK3vNTs7+Txy3Hm7fd9NSUcxOdg==",
       "dev": true,
       "dependencies": {
-        "@storybook/csf-tools": "8.1.11",
+        "@storybook/csf-tools": "8.1.8",
         "unplugin": "^1.3.1"
       },
       "funding": {
@@ -5121,9 +5148,9 @@
       }
     },
     "node_modules/@storybook/csf-tools": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.11.tgz",
-      "integrity": "sha512-6qMWAg/dBwCVIHzANM9lSHoirwqSS+wWmv+NwAs0t9S94M75IttHYxD3IyzwaSYCC5llp0EQFvtXXAuSfFbibg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.8.tgz",
+      "integrity": "sha512-5kI0q2HPGNqaedjNx4Eh5uQf3f6qSyUa14fT4GCAAGgbG0YgUeIff4N95XZ1VVeQ14epx2UK4p3+FsD58Lwnig==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "^7.24.4",
@@ -5131,7 +5158,7 @@
         "@babel/traverse": "^7.24.1",
         "@babel/types": "^7.24.0",
         "@storybook/csf": "^0.1.7",
-        "@storybook/types": "8.1.11",
+        "@storybook/types": "8.1.8",
         "fs-extra": "^11.1.0",
         "recast": "^0.23.5",
         "ts-dedent": "^2.0.0"
@@ -5148,15 +5175,15 @@
       "dev": true
     },
     "node_modules/@storybook/docs-tools": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-8.1.11.tgz",
-      "integrity": "sha512-mEXtR9rS7Y+OdKtT/QG6JBGYR1L41mcDhIqhnk7RmYl9qJstVAegrCKWR53sPKFdTVOHU7dmu6k+BD+TqHpyyw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-8.1.8.tgz",
+      "integrity": "sha512-YdwuLKIiqNFfpfBucWXt+MDvqBYmBWdm3pADTYmC9P3BI+jQ4A88LhIHYVycq8JWLxFQHSKNvgJ+Z5MFbnijIQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-common": "8.1.11",
-        "@storybook/core-events": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/core-events": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/doctrine": "^0.0.3",
         "assert": "^2.1.0",
         "doctrine": "^3.0.0",
@@ -5174,15 +5201,15 @@
       "dev": true
     },
     "node_modules/@storybook/html": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/html/-/html-8.1.11.tgz",
-      "integrity": "sha512-UrYZZGqz7UXUDXijt5Gh8y93ws4RkwYykl5AHDP22bzoOFfAER0PFE2v+Al9o7KGKdrlIJtuhWrXYREkQJ2VBA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/html/-/html-8.1.8.tgz",
+      "integrity": "sha512-0UToG5MMzC1UiTul0eg7yKB2cxDGDhWnzyUO0edG/hRNg/XJd7b//ecM2zVpqr/GMaC6WoiCrNsnJX4cBMqYkw==",
       "dev": true,
       "dependencies": {
-        "@storybook/docs-tools": "8.1.11",
+        "@storybook/docs-tools": "8.1.8",
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/preview-api": "8.1.8",
+        "@storybook/types": "8.1.8",
         "ts-dedent": "^2.0.0"
       },
       "engines": {
@@ -5194,17 +5221,17 @@
       }
     },
     "node_modules/@storybook/html-webpack5": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/html-webpack5/-/html-webpack5-8.1.11.tgz",
-      "integrity": "sha512-8SVigxNnffPz/ShR+h1vbDJjVlpIpPFp0GfaRjrbhngAv8qTe76kPjXNMK22ez0EBQtPWRPbY9irEoMuK6Ie3w==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/html-webpack5/-/html-webpack5-8.1.8.tgz",
+      "integrity": "sha512-Xq9fr39k5LjaW/s7IOg0OMcfjcTSuyWdRvQfJI82Ph1l64rawGpbUXXJgGC+jGahGMfRu+gPXIjjlnvU9/0FyQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/builder-webpack5": "8.1.11",
-        "@storybook/core-common": "8.1.11",
+        "@storybook/builder-webpack5": "8.1.8",
+        "@storybook/core-common": "8.1.8",
         "@storybook/global": "^5.0.0",
-        "@storybook/html": "8.1.11",
-        "@storybook/preset-html-webpack": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/html": "8.1.8",
+        "@storybook/preset-html-webpack": "8.1.8",
+        "@storybook/types": "8.1.8",
         "@types/node": "^18.0.0"
       },
       "engines": {
@@ -5229,16 +5256,16 @@
       }
     },
     "node_modules/@storybook/instrumenter": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.1.11.tgz",
-      "integrity": "sha512-r/U9hcqnodNMHuzRt1g56mWrVsDazR85Djz64M3KOwBhrTj5d46DF4/EE80w/5zR5JOrT7p8WmjJRowiVteOCQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.1.8.tgz",
+      "integrity": "sha512-3k8DSzZi580iO5Yr6aqjFKOySfqqi7Kfp8laHMQz5XJqDRBsrptCQkM/aYexLsb6cZqDr8kichUwikjc4wAbvA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.11",
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-events": "8.1.11",
+        "@storybook/channels": "8.1.8",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-events": "8.1.8",
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "8.1.11",
+        "@storybook/preview-api": "8.1.8",
         "@vitest/utils": "^1.3.1",
         "util": "^0.12.4"
       },
@@ -5248,9 +5275,9 @@
       }
     },
     "node_modules/@storybook/manager": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.11.tgz",
-      "integrity": "sha512-e02y9dmxowo7cTKYm9am7UO6NOHoHy6Xi7xZf/UA932qLwFZUtk5pnwIEFaZWI3OQsRUCGhP+FL5zizU7uVZeg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.8.tgz",
+      "integrity": "sha512-3d1qAIzx9TQslolwZSRvlgZ78bxL3RtesUq1NYtC/nDQ7M8Yb+X3taIk8iE/AXa2wlJ8dQ4vU5grLl/oWQeTJg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5258,20 +5285,20 @@
       }
     },
     "node_modules/@storybook/manager-api": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.1.11.tgz",
-      "integrity": "sha512-QSgwKfAw01K9YvvZj30iGBMgQ4YaCT3vojmttuqdH5ukyXkiO7pENLJj4Y+alwUeSi0g+SJeadCI3PXySBHOGg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.1.8.tgz",
+      "integrity": "sha512-mVUGMp2Z0lnuIZL8wgb++Id1tGTBtaFtB89w89U/Y5Ii8UMv2tukNiDY37HTkkVIvRz0sm9bJa94GNDrUubnTw==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.11",
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-events": "8.1.11",
+        "@storybook/channels": "8.1.8",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-events": "8.1.8",
         "@storybook/csf": "^0.1.7",
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^1.2.5",
-        "@storybook/router": "8.1.11",
-        "@storybook/theming": "8.1.11",
-        "@storybook/types": "8.1.11",
+        "@storybook/router": "8.1.8",
+        "@storybook/theming": "8.1.8",
+        "@storybook/types": "8.1.8",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
         "memoizerific": "^1.11.3",
@@ -5285,9 +5312,9 @@
       }
     },
     "node_modules/@storybook/node-logger": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.11.tgz",
-      "integrity": "sha512-wdzFo7B2naGhS52L3n1qBkt5BfvQjs8uax6B741yKRpiGgeAN8nz8+qelkD25MbSukxvbPgDot7WJvsMU/iCzg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.8.tgz",
+      "integrity": "sha512-7woDHnwd8HdssbEQnfpwZu+zNjp9X6vqdPHhxhwAYsYt3x+m0Y8LP0sMJk8w/gQygelUoJsZLFZsJ2pifLXLCg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5295,12 +5322,12 @@
       }
     },
     "node_modules/@storybook/preset-html-webpack": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-html-webpack/-/preset-html-webpack-8.1.11.tgz",
-      "integrity": "sha512-1NzEfvxFd37iBV8wINUz6Aq+aACXYHjyxnXm+Zq8knlSpYRCOonQ9cLoFFIe3/SMiVMzrpArDu4Jy2AcBt17og==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-html-webpack/-/preset-html-webpack-8.1.8.tgz",
+      "integrity": "sha512-Ftwg3upzQ8hMR3xP2hThKtKaTAA7W+UL/0rcWnsQfSTRxrkAHqosr5aXNKQFOB87RFi2oSqgd/nzuqT9ezxhAw==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-webpack": "8.1.11",
+        "@storybook/core-webpack": "8.1.8",
         "@types/node": "^18.0.0",
         "html-loader": "^3.1.0",
         "webpack": "5"
@@ -5314,9 +5341,9 @@
       }
     },
     "node_modules/@storybook/preview": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-8.1.11.tgz",
-      "integrity": "sha512-K/9NZmjnL0D1BROkTNWNoPqgL2UaocALRSqCARmkBLgU2Rn/FuZgEclHkWlYo6pUrmLNK+bZ+XzpNMu12iTbpg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-8.1.8.tgz",
+      "integrity": "sha512-xUAV/7dLRXfCRp8j/Y4c9IG8YVZ3W+Ps6OAIXWoMjHRDNdEAItka2WnOlZWjDFNHSxOR7vOh0oraYPKgBV8edQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5324,17 +5351,17 @@
       }
     },
     "node_modules/@storybook/preview-api": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.11.tgz",
-      "integrity": "sha512-8ZChmFV56GKppCJ0hnBd/kNTfGn2gWVq1242kuet13pbJtBpvOhyq4W01e/Yo14tAPXvgz8dSnMvWLbJx4QfhQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.8.tgz",
+      "integrity": "sha512-O+QnMYA5WbNvWVYcnXtzKorSbM/68QHz3Jlcjr8pRw78G478XKUACTUob/XIfZ64HGLhs7MyCjC6clHptx5kpw==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.11",
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-events": "8.1.11",
+        "@storybook/channels": "8.1.8",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-events": "8.1.8",
         "@storybook/csf": "^0.1.7",
         "@storybook/global": "^5.0.0",
-        "@storybook/types": "8.1.11",
+        "@storybook/types": "8.1.8",
         "@types/qs": "^6.9.5",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
@@ -5350,9 +5377,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.1.11.tgz",
-      "integrity": "sha512-KVDSuipqkFjpGfldoRM5xR/N1/RNmbr+sVXqMmelr0zV2jGnexEZnoa7wRHk7IuXuivLWe8BxMxzvQWqjIa4GA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.1.8.tgz",
+      "integrity": "sha512-6lzFv/H5szDCy4D7Ob7gDAS9hTfFH9Cds+LEB6dRAsCC7ZMF56hp79AZZWkT3XXTNGXcy8w4+bI7Ntk3l4+rrA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5364,12 +5391,12 @@
       }
     },
     "node_modules/@storybook/router": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.1.11.tgz",
-      "integrity": "sha512-nU5lsBvy0L8wBYOkjagh29ztZicDATpZNYrHuavlhQ2jznmmHdJvXKYk+VrMAbthjQ6ZBqfeeMNPR1UlnqR5Rw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.1.8.tgz",
+      "integrity": "sha512-7OzLdeCE+a8Ypk4Ne/2DU3s81GDNISnKIaFJ2DAuLSJbmF/LzvL39H/gyHXqmFqXWeSuCdBS0V37OEgejlZIAQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.1.11",
+        "@storybook/client-logger": "8.1.8",
         "memoizerific": "^1.11.3",
         "qs": "^6.10.0"
       },
@@ -5379,14 +5406,14 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.1.11.tgz",
-      "integrity": "sha512-Jqvm7HcZismKzPuebhyLECO6KjGiSk4ycbca1WUM/TUvifxCXqgoUPlHHQEEfaRdHS63/MSqtMNjLsQRLC/vNQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.1.8.tgz",
+      "integrity": "sha512-Hr5QUVtn4BzQrqsv1dwlfKRj2yU8XRXmhwCbo0DFULpJasVsJB3VJXeuUOijwteWsGo2avKMZErwNZElJy2yXA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-common": "8.1.11",
-        "@storybook/csf-tools": "8.1.11",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-common": "8.1.8",
+        "@storybook/csf-tools": "8.1.8",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -5451,20 +5478,20 @@
       }
     },
     "node_modules/@storybook/test": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.1.11.tgz",
-      "integrity": "sha512-k+V3HemF2/I8fkRxRqM8uH8ULrpBSAAdBOtWSHWLvHguVcb2YA4g4kKo6tXBB9256QfyDW4ZiaAj0/9TMxmJPQ==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.1.8.tgz",
+      "integrity": "sha512-SuKQZ2VPBLRK7zgkK+BAzau0HHdYjcsHFbVFa3E4r5n29KRXziW0hOcyBqMRh3jVi9tWKswTmDAOaPfPCxQjHA==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.1.11",
-        "@storybook/core-events": "8.1.11",
-        "@storybook/instrumenter": "8.1.11",
-        "@storybook/preview-api": "8.1.11",
-        "@testing-library/dom": "10.1.0",
-        "@testing-library/jest-dom": "6.4.5",
-        "@testing-library/user-event": "14.5.2",
-        "@vitest/expect": "1.6.0",
-        "@vitest/spy": "1.6.0",
+        "@storybook/client-logger": "8.1.8",
+        "@storybook/core-events": "8.1.8",
+        "@storybook/instrumenter": "8.1.8",
+        "@storybook/preview-api": "8.1.8",
+        "@testing-library/dom": "^9.3.4",
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/user-event": "^14.5.2",
+        "@vitest/expect": "1.3.1",
+        "@vitest/spy": "^1.3.1",
         "util": "^0.12.4"
       },
       "funding": {
@@ -5473,13 +5500,13 @@
       }
     },
     "node_modules/@storybook/theming": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.1.11.tgz",
-      "integrity": "sha512-Chn/opjO6Rl1isNobutYqAH2PjKNkj09YBw/8noomk6gElSa3JbUTyaG/+JCHA6OG/9kUsqoKDb5cZmAKNq/jA==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.1.8.tgz",
+      "integrity": "sha512-QhRMSRpnWVD1IB5sTZXVI35ETSQdwGh4/g8gKlGol8MN2Behd7CFgFAj2UL4jpPgjhnioH0U4rwwLkRfDlkR6Q==",
       "dev": true,
       "dependencies": {
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-        "@storybook/client-logger": "8.1.11",
+        "@storybook/client-logger": "8.1.8",
         "@storybook/global": "^5.0.0",
         "memoizerific": "^1.11.3"
       },
@@ -5501,12 +5528,12 @@
       }
     },
     "node_modules/@storybook/types": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.11.tgz",
-      "integrity": "sha512-k9N5iRuY2+t7lVRL6xeu6diNsxO3YI3lS4Juv3RZ2K4QsE/b3yG5ElfJB8DjHDSHwRH4ORyrU71KkOCUVfvtnw==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.8.tgz",
+      "integrity": "sha512-bWg6WkhnhkWBIu03lUKlX2eOYSjDzpzoulzLh1H4Tl1JReGed+cHbIpdIU6lke2aJyb2BNyzoyudUHKBBGaOzg==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.11",
+        "@storybook/channels": "8.1.8",
         "@types/express": "^4.7.0",
         "file-system-cache": "2.3.0"
       },
@@ -5729,22 +5756,22 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
+        "aria-query": "5.1.3",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/dom/node_modules/ansi-styles": {
@@ -5800,12 +5827,12 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
-      "integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
+      "integrity": "sha512-8qpnGVincVDLEcQXWaHOf6zmlbwTKc6Us6PPu4CRnPXCzo2OGBS5cwgMMOWdxDpEz1mkbvXHpEy99M5Yvt682w==",
       "dev": true,
       "dependencies": {
-        "@adobe/css-tools": "^4.3.2",
+        "@adobe/css-tools": "^4.4.0",
         "@babel/runtime": "^7.9.2",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
@@ -6562,18 +6589,77 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
-      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.1.tgz",
+      "integrity": "sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/spy": "1.3.1",
+        "@vitest/utils": "1.3.1",
         "chai": "^4.3.10"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/spy": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.1.tgz",
+      "integrity": "sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.1.tgz",
+      "integrity": "sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/@vitest/spy": {
       "version": "1.6.0",
@@ -7087,12 +7173,12 @@
       "dev": true
     },
     "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
       "dependencies": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -7100,7 +7186,6 @@
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -8084,9 +8169,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.24.tgz",
-      "integrity": "sha512-5xQNN2SVBdZv4TxeMLaI+PelrnZsHDhn8h2JtyriLr+0qHcZS8BMuo93qN6J1VmtmrgYP+rmcLHcbpnA8QJh+w==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.23.tgz",
+      "integrity": "sha512-1o/gLU9wDqbN5nL2MtfjykjOuighGXc3/hnWueO1haiEoFgX8h5vbvcA4tgdQfjw1mkZ1OEF4x/+HVeqEX6NoA==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.1",
@@ -8959,6 +9044,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -9560,6 +9677,26 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -10857,9 +10994,9 @@
       "peer": true
     },
     "node_modules/flow-parser": {
-      "version": "0.238.2",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.238.2.tgz",
-      "integrity": "sha512-fs7FSnzzKF6oSzjk14JlBHt82DPchYHVsXtPi4Fkn+qrunVjWaBZY7nSO/mC9X4l9+wRah/R69DRd5NGDOrWqw==",
+      "version": "0.237.2",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.237.2.tgz",
+      "integrity": "sha512-mvI/kdfr3l1waaPbThPA8dJa77nHXrfZIun+SWvFwSwDjmeByU7mGJGRmv1+7guU6ccyLV8e1lqZA1lD4iMGnQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -11171,7 +11308,6 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11501,7 +11637,6 @@
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -12025,7 +12160,6 @@
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -12099,7 +12233,6 @@
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -12138,7 +12271,6 @@
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -12163,7 +12295,6 @@
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -12220,7 +12351,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -12345,7 +12475,6 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12396,7 +12525,6 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -12440,7 +12568,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -12457,7 +12584,6 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12470,7 +12596,6 @@
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -12498,7 +12623,6 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -12514,7 +12638,6 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -12557,7 +12680,6 @@
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12583,7 +12705,6 @@
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
       "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4"
@@ -12611,8 +12732,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -17161,16 +17281,16 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.12.1.tgz",
-      "integrity": "sha512-1GxY8dnEnHr1SLzdSDr0FCjM6JQfAh2E2I/EqzeF8a58DbGVk9oVjj4lFdqNoVbpgFSpAbz7VER9St7S1wDpNg==",
+      "version": "22.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.11.2.tgz",
+      "integrity": "sha512-8fjdQSgW0sq7471ftca24J7sXK+jXZ7OW7Gx+NEBFNyXrcTiBfukEI46gNq6hiMhbLEDT30NeylK/1ZoPdlKSA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
-        "cosmiconfig": "^9.0.0",
+        "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1299070",
-        "puppeteer-core": "22.12.1"
+        "puppeteer-core": "22.11.2"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -17180,16 +17300,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.12.1.tgz",
-      "integrity": "sha512-XmqeDPVdC5/3nGJys1jbgeoZ02wP0WV1GBlPtr/ULRbGXJFuqgXMcKQ3eeNtFpBzGRbpeoCGWHge1ZWKWl0Exw==",
+      "version": "22.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.11.2.tgz",
+      "integrity": "sha512-vQo+YDuePyvj+92Z9cdtxi/HalKf+k/R4tE80nGtQqJRNqU81eHaHkbVfnLszdaLlvwFF5tipnnSCzqWlEddtw==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
-        "chromium-bidi": "0.5.24",
-        "debug": "^4.3.5",
+        "chromium-bidi": "0.5.23",
+        "debug": "4.3.5",
         "devtools-protocol": "0.0.1299070",
-        "ws": "^8.17.1"
+        "ws": "8.17.1"
       },
       "engines": {
         "node": ">=18"
@@ -17384,12 +17504,12 @@
       "dev": true
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
-      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
       "dev": true,
       "dependencies": {
-        "react-remove-scroll-bar": "^2.3.4",
+        "react-remove-scroll-bar": "^2.3.3",
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.1.0",
         "use-callback-ref": "^1.3.0",
@@ -17706,7 +17826,6 @@
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -18234,7 +18353,6 @@
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -18495,6 +18613,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/store2": {
       "version": "2.14.3",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.3.tgz",
@@ -18502,12 +18632,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "8.1.11",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.1.11.tgz",
-      "integrity": "sha512-3KjIhF8lczXhKKHyHbOqV30dvuRYJSxc0d1as/C8kybuwE7cLaydhWGma7VBv5bTSPv0rDzucx7KcO+achArPg==",
+      "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.1.8.tgz",
+      "integrity": "sha512-2ld3JEmPWy3KOksfF0Reyiq5SC+dYBzV2XW2/YTkNkLTkyNofhdPeq71COGcB0Lq2PHZkZyNin8htQWbh0LLNg==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "8.1.11"
+        "@storybook/cli": "8.1.8"
       },
       "bin": {
         "sb": "index.js",
@@ -20295,7 +20425,6 @@
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -20339,7 +20468,6 @@
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jest-cli": "^29.7.0",
     "lint-staged": "^15.2.0",
     "prettier": "^3.1.1",
-    "puppeteer": "22.12.*",
+    "puppeteer": "22.11.*",
     "storybook": "^8.1.6"
   },
   "license": "MIT"


### PR DESCRIPTION
Reverts thebiggive/components#527

That apparently made donate-frontend server side rendering hundreds of times slower - taking 15 seconds instead of just 0.1 seconds. I guess it must be something in the update to stencil 4.19.0. 