### PR TITLE
Update @stencil/core to 4.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
         "@fortawesome/pro-regular-svg-icons": "^6.1.2",
         "@fortawesome/pro-solid-svg-icons": "^6.1.2",
-        "@stencil/core": "^4.9.0"
+        "@stencil/core": "^4.19.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.5.0",
@@ -4133,9 +4133,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
-      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.0.tgz",
+      "integrity": "sha512-Lky99+K9guu5fFMi3ows9q6p0/gjuZmfmVHxcPMQa5QZKSwG+D19u7G1xcd3p6I+xIfwk71gFxrmcKU1gaOCdg==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
     "@fortawesome/pro-regular-svg-icons": "^6.1.2",
     "@fortawesome/pro-solid-svg-icons": "^6.1.2",
-    "@stencil/core": "^4.9.0"
+    "@stencil/core": "^4.19.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.5.0",


### PR DESCRIPTION
I think this may break FE as happened on Friday (15s initial load time) but I want to do it anyway to be sure. As soon as I see if it broke it I'll try to fix by updating to 4.19.1 and if that doesn't work going back to 4.18.3