### PR TITLE
Downgrade stencil core back to 4.18 - 4.19 seems to cause a very slow…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
         "@fortawesome/pro-regular-svg-icons": "^6.1.2",
         "@fortawesome/pro-solid-svg-icons": "^6.1.2",
-        "@stencil/core": "^4.19.1"
+        "@stencil/core": "~4.18.3"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.5.0",
@@ -4133,9 +4133,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.1.tgz",
-      "integrity": "sha512-fjSBctHrobeSL2+XcuX7GVk/eaUhZ/lvIu21RJmzHAPcNyueuSAEv7J/Isn4UlYNk70o+yOK72H0FTlNkUibvw==",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
     "@fortawesome/pro-regular-svg-icons": "^6.1.2",
     "@fortawesome/pro-solid-svg-icons": "^6.1.2",
-    "@stencil/core": "^4.19.1"
+    "@stencil/core": "~4.18.3"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.5.0",


### PR DESCRIPTION
… 15s initial page load on frontend