### PR TITLE
DON-976: Allow long names in text input prompts

### DIFF
--- a/src/components/biggive-text-input/biggive-text-input.scss
+++ b/src/components/biggive-text-input/biggive-text-input.scss
@@ -6,9 +6,7 @@
 
 ::slotted([slot=label]) {
   display: inline-block;
-  overflow: hidden;
   line-height: 1.2; // Slightly less than other text to help with long charity names.
-  max-height: 2rem; // Essential to not obscure amount on some high DPI, small screens.
 }
 
 .text-input {
@@ -17,15 +15,20 @@
   }
   position: relative;
   .prompt {
-    position: absolute;
+    position: relative;
     z-index: 2;
     font-size: small;
-    top: -1em;
-    background-color: $colour-grey-background;
+    top: 1em;
     left: 4em;
-    padding-left: 1em;
-    padding-right: 1em;
     color: $colour-primary-blue;
+    max-width: calc(100% - 10em);
+    display: inline-block;
+
+    > span {
+      padding-left: 1em;
+      padding-right: 1em;
+      background-color: $colour-grey-background;
+    }
   }
 
   @include standard-font();

--- a/src/components/biggive-text-input/biggive-text-input.tsx
+++ b/src/components/biggive-text-input/biggive-text-input.tsx
@@ -24,15 +24,17 @@ export class BiggiveTextInput {
     const currencySymbol = this.currency === 'GBP' ? '£' : this.currency === 'USD' ? '$' : undefined;
     return (
       <div class={'text-input space-below-' + this.spaceBelow + ' select-style-' + this.selectStyle}>
+        <div class="prompt">
+          <span>
+            <slot name="label" />
+          </span>
+        </div>
         <div class="sleeve">
           <div class="inner-sleave">
             {currencySymbol && <span class="currency-symbol">{currencySymbol}</span>}
             <slot name="input" />
             <div style={{ clear: 'both' }}></div>
           </div>
-        </div>
-        <div class="prompt">
-          <slot name="label" />
         </div>
       </div>
     );

--- a/src/index.html
+++ b/src/index.html
@@ -874,8 +874,9 @@
           will have to be passed from the CSS file of that app. Would be happier if it could be inside the stencil component
           but that won't allow two way binding the data to the input
           -->
+
         <biggive-text-input currency="GBP">
-          <label for="enter-donation-amount" slot="label">Enter your donation amount</label>
+          <label for="enter-donation-amount" slot="label">Enter your donation amount for very very long and really quite hard to read not at all short charity name like this one here</label>
           <input
             id="enter-donation-amount"
             slot="input"
@@ -883,6 +884,69 @@
             style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
           />
         </biggive-text-input>
+
+        <biggive-text-input currency="GBP">
+          <label for="enter-donation-amount" slot="label">Enter your donation amount for short charity name</label>
+          <input
+            id="enter-donation-amount"
+            slot="input"
+            value="60.00"
+            style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
+          />
+        </biggive-text-input>
+
+        <biggive-text-input currency="GBP">
+          <label for="enter-donation-amount" slot="label">Enter your donation amount for MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM XXXXXXXxxx</label>
+          <input
+            id="enter-donation-amount"
+            slot="input"
+            value="60.00"
+            style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
+          />
+        </biggive-text-input>
+
+        <biggive-text-input currency="GBP">
+          <label for="enter-donation-amount" slot="label">Enter your donation amount for MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMM MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM  XXXXXXXxxx</label>
+          <input
+            id="enter-donation-amount"
+            slot="input"
+            value="60.00"
+            style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
+          />
+        </biggive-text-input>
+
+
+        <biggive-text-input currency="GBP">
+          <label for="enter-donation-amount" slot="label">Donation to Acme Arts Ltd</label>
+          <input
+            id="enter-donation-amount"
+            slot="input"
+            value="60.00"
+            style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
+          />
+        </biggive-text-input>
+
+        <biggive-text-input currency="GBP">
+          <label for="enter-donation-amount" slot="label">Donation to ACME CONTEMPORARY ARTISTIC COLLECTIVE</label>
+          <input
+            id="enter-donation-amount"
+            slot="input"
+            value="60.00"
+            style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
+          />
+        </biggive-text-input>
+
+        <biggive-text-input currency="GBP">
+          <label for="enter-donation-amount" slot="label">Donation to Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</label>
+          <input
+            id="enter-donation-amount"
+            slot="input"
+            value="60.00"
+            style="float: right; outline: none; border: none; background-color: #F6F6F6; text-align: right; font-size: 24px; line-height: 30px; font-weight: bolder; width: 100%;"
+          />
+        </biggive-text-input>
+
+
       </div>
       <biggive-tipping-slider percentage-start="0" percentage-end="30" donation-amount="200" donation-currency="GBP"></biggive-tipping-slider>
 


### PR DESCRIPTION
If the name requires multiple lines to render it will now take up vertical space on the page, pushing the actual input and everything below it down.

Screenshots below showing the components repo index page on a variety of page widths. Will need testing in frontend before we can know for sure if this is good. The only cases where the layout really doesn't work seem to be where the prompt has an extremely wide individual word.

![image](https://github.com/thebiggive/components/assets/159481/f7bc090b-2ca4-4383-bd02-687f514b8f25)

![image](https://github.com/thebiggive/components/assets/159481/2f77c455-9f44-47bd-9eb3-81c39e384f3c)

![image](https://github.com/thebiggive/components/assets/159481/d66e1397-e1e8-4f27-bd6f-e9ebe39e9226)

![image](https://github.com/thebiggive/components/assets/159481/3dd45836-3594-4f3f-be1d-e49c4058a68d)
