### PR TITLE
COM-99: Change form field select border from blue to coral when focused

### DIFF
--- a/src/components/biggive-form-field-select/biggive-form-field-select.scss
+++ b/src/components/biggive-form-field-select/biggive-form-field-select.scss
@@ -54,7 +54,47 @@ select.grey {
   text-align: left;
   &.select-style-bordered {
     .sleeve {
-      @include dropdown();
+      @include font-size-medium();
+      padding: 2px;
+      position: relative;
+      background-color: $colour-primary-blue;
+      @include corner-clip-small-top-right();
+      select {
+        color: $colour-primary-blue;
+        display: block;
+        position: relative;
+        padding: 10px 80px 10px 10px;
+        clip-path:
+          polygon(
+              0% 0%,     /* top left */
+              0% 0%,     /* top left */
+              calc(100% - 14px) 0%,    /* top right */
+              100% 14px,   /* top right */
+              100% 100%,  /* bottom right */
+              100% 100%,  /* bottom right */
+              0 100%,   /* bottom left */
+              0 100%      /* bottom left */
+          );
+        span.placeholder.grey {
+          background-color: $colour-grey-background;
+        }
+      }
+      div.arrow {
+        position: absolute;
+        right: 20px;
+        top: 18px;
+        width: 10px;
+        height: 10px;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI3IiB2aWV3Qm94PSIwIDAgOSA3IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNS4yMzcxNiA2LjYyNDkzQzQuOTAzMjMgNy4xMjUwMiA0LjA5NyA3LjEyNTAyIDMuNzYzMDggNi42MjQ5M0wwLjEyMzg2OCAxLjE3MDYzQy0wLjIxOTk0IDAuNjU1NDU5IDAuMTkyNjMgMS44MzcxZS0wNyAwLjg2MDkwOCAyLjQyMTMyZS0wN0w4LjEzOTMzIDguNzg0MzJlLTA3QzguODA3MTggOS4zNjgxN2UtMDcgOS4yMTk3NSAwLjY1NTQ1OSA4Ljg3NjM3IDEuMTcwNjNMNS4yMzcxNiA2LjYyNDkzWiIgZmlsbD0iIzJDMDg5QiIvPgo8L3N2Zz4K');
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position: center center;
+        z-index: 1;
+        pointer-events: none;
+      }
+    }
+    .sleeve:focus-within {
+      background-color: $colour-tertiary-coral;
     }
   }
   &.select-style-underlined {

--- a/src/globals/mixins.scss
+++ b/src/globals/mixins.scss
@@ -335,47 +335,6 @@
   }
 }
 
-@mixin dropdown {
-  @include font-size-medium();
-  padding: 2px;
-  position: relative;
-  background-color: $colour-primary-blue;
-  @include corner-clip-small-top-right();
-  select {
-    color: $colour-primary-blue;
-    display: block;
-    position: relative;
-    padding: 10px 80px 10px 10px;
-    clip-path:
-    polygon(
-      0% 0%,     /* top left */
-      0% 0%,     /* top left */
-      calc(100% - 14px) 0%,    /* top right */
-      100% 14px,   /* top right */
-      100% 100%,  /* bottom right */
-      100% 100%,  /* bottom right */
-      0 100%,   /* bottom left */
-      0 100%      /* bottom left */
-    );
-    span.placeholder.grey {
-      background-color: $colour-grey-background;
-    }
-  }
-  div.arrow {
-    position: absolute;
-    right: 20px;
-    top: 18px;
-    width: 10px;
-    height: 10px;
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI3IiB2aWV3Qm94PSIwIDAgOSA3IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNS4yMzcxNiA2LjYyNDkzQzQuOTAzMjMgNy4xMjUwMiA0LjA5NyA3LjEyNTAyIDMuNzYzMDggNi42MjQ5M0wwLjEyMzg2OCAxLjE3MDYzQy0wLjIxOTk0IDAuNjU1NDU5IDAuMTkyNjMgMS44MzcxZS0wNyAwLjg2MDkwOCAyLjQyMTMyZS0wN0w4LjEzOTMzIDguNzg0MzJlLTA3QzguODA3MTggOS4zNjgxN2UtMDcgOS4yMTk3NSAwLjY1NTQ1OSA4Ljg3NjM3IDEuMTcwNjNMNS4yMzcxNiA2LjYyNDkzWiIgZmlsbD0iIzJDMDg5QiIvPgo8L3N2Zz4K');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center center;
-    z-index: 1;
-    pointer-events: none;
-  }
-}
-
 @mixin dropdown-underlined {
   @include font-size-medium();
   padding: 1px;


### PR DESCRIPTION
This works for the drop-down parts of the donate form. Not sure yet how we can do the text inputs, still needs thought, and if we can't find a way to make that work its possible we'll have to revert this since having focus displayed on the drop downs but not on text inputs might make things more confusing.

Will affect not only the donate form as the ticket is focused on but everything else that uses this select component, including the contact us form on the wordpress site. I think that's actually it for now.

![image](https://github.com/user-attachments/assets/390d9ed4-ca23-4189-aa56-964c3098a88e)
