### PR TITLE
Hero vertical space tweaks

### DIFF
--- a/src/components/biggive-hero-image/biggive-hero-image.scss
+++ b/src/components/biggive-hero-image/biggive-hero-image.scss
@@ -40,7 +40,7 @@
       &.logo-height-7 { height: 200px; }
       &.logo-height-8 { height: 225px; }
       &.logo-height-9 { height: 250px; }
-      &.logo-height-10 { height: 275px; }    
+      &.logo-height-10 { height: 275px; }
     }
 
     .logo {
@@ -70,8 +70,11 @@
       }
     }
     .teaser {
-      margin: 0 0 $spacer-5 0;
+      margin: 0;
       padding: 0;
+    }
+    .teaser-with-space {
+      margin: 0 0 $spacer-5 0;
     }
   }
 

--- a/src/components/biggive-hero-image/biggive-hero-image.tsx
+++ b/src/components/biggive-hero-image/biggive-hero-image.tsx
@@ -100,7 +100,9 @@ export class BiggiveHeroImage {
 
   render() {
     const mainTitleClasses = 'main-title ' + (typeof this.mainTitleColour === 'string' && this.mainTitleColour.length > 0 ? `text-colour-${this.mainTitleColour}` : '');
-    const teaserClasses = 'teaser ' + (typeof this.teaserColour === 'string' && this.teaserColour.length > 0 ? `text-colour-${this.teaserColour}` : '');
+    const teaserClasses = 'teaser ' +
+      (this.buttonLabel?.length > 0 ? 'teaser-with-space ' : '') +
+      (typeof this.teaserColour === 'string' && this.teaserColour.length > 0 ? `text-colour-${this.teaserColour}` : '');
 
     return (
       <div class={'container colour-scheme-' + this.colourScheme + ' space-below-' + this.spaceBelow}

--- a/src/components/biggive-hero-image/biggive-hero-image.tsx
+++ b/src/components/biggive-hero-image/biggive-hero-image.tsx
@@ -102,7 +102,7 @@ export class BiggiveHeroImage {
     const mainTitleClasses = 'main-title ' + (typeof this.mainTitleColour === 'string' && this.mainTitleColour.length > 0 ? `text-colour-${this.mainTitleColour}` : '');
     const teaserClasses = 'teaser ' +
       (this.buttonLabel?.length > 0 ? 'teaser-with-space ' : '') +
-      (typeof this.teaserColour === 'string' && this.teaserColour.length > 0 ? `text-colour-${this.teaserColour}` : '');
+      (this.teaserColour?.length > 0 ? `text-colour-${this.teaserColour}` : '');
 
     return (
       <div class={'container colour-scheme-' + this.colourScheme + ' space-below-' + this.spaceBelow}

--- a/src/components/biggive-hero-image/biggive-hero-image.tsx
+++ b/src/components/biggive-hero-image/biggive-hero-image.tsx
@@ -102,7 +102,7 @@ export class BiggiveHeroImage {
     const mainTitleClasses = 'main-title ' + (typeof this.mainTitleColour === 'string' && this.mainTitleColour.length > 0 ? `text-colour-${this.mainTitleColour}` : '');
     const teaserClasses = 'teaser ' +
       (this.buttonLabel?.length > 0 ? 'teaser-with-space ' : '') +
-      (this.teaserColour?.length > 0 ? `text-colour-${this.teaserColour}` : '');
+      (typeof this.teaserColour === 'string' && this.teaserColour.length > 0 ? `text-colour-${this.teaserColour}` : '');
 
     return (
       <div class={'container colour-scheme-' + this.colourScheme + ' space-below-' + this.spaceBelow}

--- a/src/components/biggive-hero-image/biggive-hero-image.tsx
+++ b/src/components/biggive-hero-image/biggive-hero-image.tsx
@@ -115,7 +115,10 @@ export class BiggiveHeroImage {
                 <img src={this.logo} alt={this.logoAltText} title={this.logoAltText}/>
               </div>
             ) : <div class={'logo-space logo-height-'+this.logoHeight}></div>}
-            <div class={'slug text-colour-'+this.slugColour}>{this.slug}</div>
+            {this.logo?.length > 0 || this.slug?.length > 0
+              ? (<div class={'slug text-colour-'+this.slugColour}>{this.slug}</div>)
+              : null
+            }
             <h1 class={mainTitleClasses}>{this.mainTitle}</h1>
             <div class={teaserClasses}>{this.teaser}</div>
             {this.buttonLabel != null && this.buttonUrl != null


### PR DESCRIPTION
* Avoid 50px plus 45px double bottom margins if there are no buttons that require post-teaser space; keep just the `.content-wrap` 50px in that case
* Avoid 20px empty "slug" if there is no slug text and there is no champion logo which would otherwise look cramped against the title