### PR TITLE
Grid fix for large tablet & small desktop breakpoints

### DIFF
--- a/src/components/biggive-grid/biggive-grid.scss
+++ b/src/components/biggive-grid/biggive-grid.scss
@@ -97,7 +97,7 @@
 
 
 
-@media screen and (max-width: $screen-tablet-max) {
+@media screen and (max-width: $screen-large) {
 
   @for $i from 1 through 6 {
     .column-count-#{$i}  ::slotted(*) { width: calc( 51% - (($spacer-4 * 1) / 2)) };

--- a/src/components/biggive-grid/biggive-grid.stories.tsx
+++ b/src/components/biggive-grid/biggive-grid.stories.tsx
@@ -35,7 +35,7 @@ const Template = (args: any) => `
               space-below='4'
               icon-colour='primary'
               background-image-url='https://media.istockphoto.com/vectors/childish-seamless-dotted-pattern-with-colorful-doodle-letters-fun-vector-id1208462693'
-              main-title='Sample main title'
+              main-title='Middle East Humanitarian Appeal'
               subtitle='Sample subtitle'
               button-url='#'
               button-label='Click here'


### PR DESCRIPTION
Avoid clipped words & improve squashed appearance. Staging before this change:

<img width="752" alt="Screenshot 2024-10-24 at 11 05 52" src="https://github.com/user-attachments/assets/e5a986ef-a700-40c8-b9f3-c17202803b61">

A review in Storybook (with updated sample copy) suggests there shouldn't be wider impact on layouts from the change. The example changes to 2 cols at similar viewport widths to the Donate example.