### PR TITLE
DON-961: Fix hero image layout issue in server side render

### DIFF
--- a/src/components/biggive-hero-image/biggive-hero-image.scss
+++ b/src/components/biggive-hero-image/biggive-hero-image.scss
@@ -26,7 +26,6 @@
     width: 40%;
     position: relative;
     z-index: 1;
-    white-space: pre-wrap; // helps render out \n
     padding: $spacer-8 $spacer-6 $spacer-6 $spacer-0;
 
     .logo, .logo-space {

--- a/src/components/biggive-hero-image/biggive-hero-image.tsx
+++ b/src/components/biggive-hero-image/biggive-hero-image.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable prettier/prettier */
-import { Component, Prop, h } from '@stencil/core';
-import { brandColour } from '../../globals/brand-colour';
-import { spacingOption } from '../../globals/spacing-option';
+import {Component, h, Prop} from '@stencil/core';
+import {brandColour} from '../../globals/brand-colour';
+import {spacingOption} from '../../globals/spacing-option';
 
 
 @Component({
@@ -104,6 +104,11 @@ export class BiggiveHeroImage {
       (this.buttonLabel?.length > 0 ? 'teaser-with-space ' : '') +
       (typeof this.teaserColour === 'string' && this.teaserColour.length > 0 ? `text-colour-${this.teaserColour}` : '');
 
+    // Charities can use line breaks in their copy so we convert them to BR tags to display. Using this rather than
+    // `pre` or `pre-wrap` so that literal whitespace inserted into the rendered output doesn't affect the layout.
+    // Assuming that this is needed only for the teaser, and the main title would never contain a line break.
+    const teaserLines = this.lineBreakToBr(this.teaser);
+
     return (
       <div class={'container colour-scheme-' + this.colourScheme + ' space-below-' + this.spaceBelow}
            style={this.mainImageShape === 'rectangle' ?  {'background-image': 'url(' + this.mainImage + ')', 'background-size': 'cover'} : {}}
@@ -120,7 +125,7 @@ export class BiggiveHeroImage {
               : null
             }
             <h1 class={mainTitleClasses}>{this.mainTitle}</h1>
-            <div class={teaserClasses}>{this.teaser}</div>
+            <div class={teaserClasses}>{teaserLines}</div>
             {this.buttonLabel != null && this.buttonUrl != null
               ? <biggive-button colour-scheme={this.buttonColourScheme} url={this.buttonUrl} label={this.buttonLabel}></biggive-button>
               : null
@@ -139,5 +144,16 @@ export class BiggiveHeroImage {
           </div>
       </div>
     );
+  }
+
+  /**
+   * Takes a string that may contain any form of newlines, and returns an array that alternates
+   * between substrings found between the newlines and <br/> elements as objects.
+   */
+  private lineBreakToBr(string: string): unknown[] {
+    return string.split(/\r?\n|\r|\n/g)
+      .map(line => [line, <br/>])
+      .flat()
+      .slice(0, -1);
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -56,9 +56,10 @@
         colour-scheme="primary"
         main-title="Christmas Challenge 2024"
         main-title-colour="primary"
-        main-image="http://biggive.thomas-paterson.co.uk/wp-content/uploads/2023/02/Grid.png"
         main-image-shape="rectangle"
-        teaser="The Christmas Challenge takes place from 29 November to 6 December. We are aiming to raise £22.5 million for participating charities. One donation, twice the impact."
+        teaser="The Christmas Challenge takes place from 29 November to 6 December. We are aiming to raise £22.5 million for participating charities. One donation, twice the impact.
+
+        And we used a couple of line breaks here to simulate a new paragraph."
         button-url="https://www.google.com"
         button-label="Donate now"
         logo="/assets/images/sample-champion.png"


### PR DESCRIPTION
Currently when we do a server side render something (not sure what) that I think is part of our Stencil library inserts whitespace and comments that show the HYDRATE_CHILD_ID / c-id of various elements, e.g.:

                    <div c-id="44702.7.3.2" class="teaser">
                      <!--t.44702.8.4.0-->
                      Hi. We’re Big Give. Our match funding campaigns offer a unique opportunity for you to double the difference you can make in the world for the causes close to your heart.
                    </div>

This combined with our use of `whitespace: pre-wrap` removed here meant the layout of our main title and subtitle on the homepage was messed up in the SSR version of the page, and visible moved between rendering that and the client side rendered version.

So removing `pre-wrap` here and replacing with `<br/>` tags.


![image](https://github.com/user-attachments/assets/5326883e-dcba-4454-9090-828ffea3e43c)
