### PR TITLE
COM-101: Fix 404 error fetching 'undefined' image in campaign card

### DIFF
--- a/src/components/biggive-campaign-card/biggive-campaign-card.tsx
+++ b/src/components/biggive-campaign-card/biggive-campaign-card.tsx
@@ -130,7 +130,7 @@ export class BiggiveCampaignCard {
               </div>
             ) : null}
 
-            {this.banner !== null ? (
+            {this.banner !== null && this.banner !== undefined ? (
               <div class="image-wrap banner" role="presentation" style={{ 'background-image': 'url(' + this.banner + ')' }}></div>
             ) : (
               <div class="image-wrap banner"></div>


### PR DESCRIPTION
Issue listed as #3 in my comment on the ticket yesterday at 17:30

This fixes the immediate thing but I'm not very happy about it because we're likely to keep having to do similar fixes everywhere - looks like at least all stencil props that rely on data fetched at runtime are ending up undefined during the initial server side render