### PR TITLE
COM-101 – try prefix asset paths with /

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ For now:
   addition to an `angular.json` `"styles"` key:
   `"node_modules/@biggive/components/dist/biggive/assets/fonts/EuclidTriangle/stylesheet.css"`
 * Images are also copied with a Stencil `copy` task, and fixed references use getAssetPath() plus
-  a path, e.g. `getAssetPath('assets/images/banner.png')`. See the
+  a path, e.g. `getAssetPath('/assets/images/banner.png')`. See the
   [Stencil asset docs](https://stenciljs.com/docs/assets) for more on this. Angular seems to be
   able to use this without `setAssetPath()` if we config its `"assets"` key to put files in the same
   folder as the app's own images. This is the approach taken on [this proof of concept branch](https://github.com/thebiggive/donate-frontend/tree/COM-5-proof-of-concept).

--- a/src/components/biggive-back-to-top/biggive-back-to-top.tsx
+++ b/src/components/biggive-back-to-top/biggive-back-to-top.tsx
@@ -10,7 +10,7 @@ export class BiggiveBackToTop {
     return (
       <div class="container">
         <a href="#">
-          <img src={getAssetPath('assets/images/triangles-combined.svg')} />
+          <img src={getAssetPath('/assets/images/triangles-combined.svg')} />
           <span class="text">Back to top</span>
         </a>
       </div>

--- a/src/components/biggive-footer/biggive-footer.tsx
+++ b/src/components/biggive-footer/biggive-footer.tsx
@@ -74,7 +74,7 @@ export class BiggiveFooter {
 
           <div class="row row-bottom">
             <div class="postscript-wrap">
-              <img class="fr-logo" src={getAssetPath('assets/images/fundraising-regulator.png')} alt="Registered with FUNDRAISING REGULATOR" />
+              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Registered with FUNDRAISING REGULATOR" />
 
               <nav class="nav nav-postscript" aria-label="Legal"></nav>
             </div>
@@ -195,7 +195,7 @@ export class BiggiveFooter {
 
           <div class="row row-bottom">
             <div class="postscript-wrap">
-              <img class="fr-logo" src={getAssetPath('assets/images/fundraising-regulator.png')} alt="Registered with FUNDRAISING REGULATOR" />
+              <img class="fr-logo" src={getAssetPath('/assets/images/fundraising-regulator.png')} alt="Registered with FUNDRAISING REGULATOR" />
 
               <nav class="nav nav-postscript" aria-label="Legal">
                 <ul slot="nav-postscript">


### PR DESCRIPTION
Although this is a step away from the Stencil docs, we are seeing load problems with WordPress treating asset paths as relative so it seems worth a go.