### PR TITLE
COM-102 – adjust how we position content below the menu

### DIFF
--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -116,7 +116,6 @@ nav {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   height: $nav-height-desktop;
   background: white;
   z-index: 99;

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -7,7 +7,7 @@ import { makeURL } from '../../util/helper-methods';
   shadow: true,
 })
 export class BiggiveMainMenu {
-  private lastOffsetHeight = 0;
+  private lastScrollHeight = 0;
 
   @Element() host: HTMLBiggiveMainMenuElement;
 
@@ -50,20 +50,24 @@ export class BiggiveMainMenu {
   }
 
   private setHeaderSize() {
-    if (this.host.offsetHeight === this.lastOffsetHeight) {
+    if (this.host.scrollHeight === this.lastScrollHeight) {
       // Some browsers fire 'resize' overzealously on scroll; we don't want to cause extra paints if nothing
       // relevant changed.
       return;
     }
 
-    this.lastOffsetHeight = this.host.offsetHeight;
+    this.lastScrollHeight = this.host.scrollHeight;
 
     // Some resize edge cases lead Firefox, and maybe others, to go haywire and get a host offset
     // height of millions of pixels, presumably due to a layout logic loop. So for as long as we use
     // this body padding workaround, we need a safe maximum value, currently 130px, beyond which
     // we will never further displace the main content.
-    const offsetHeight = isNaN(this.host.offsetHeight) ? 0 : this.host.offsetHeight;
-    document.body.style.paddingTop = Math.min(130, offsetHeight).toString() + 'px';
+    // (Possibly scrollHeight could have the same issue, not tested.)
+    const scrollHeight = isNaN(this.host.scrollHeight) ? 60 : this.host.scrollHeight;
+    console.log('scroll height', this.host.scrollHeight);
+    console.log('offset height', this.host.offsetHeight);
+
+    document.body.style.paddingTop = Math.min(130, scrollHeight).toString() + 'px';
   }
 
   componentDidLoad() {
@@ -72,10 +76,6 @@ export class BiggiveMainMenu {
       this.setHeaderSize();
     });
     this.setHeaderSize();
-
-    // repeat setting header size in attempt to workaround issue in COM-102 comments with the total raised box
-    // being hidden behind menu in some cases on Safari.
-    window.setTimeout(() => this.setHeaderSize(), 1000);
 
     const subMenuElements = this.host.shadowRoot!.querySelectorAll<HTMLElement>('.sub-menu');
     if (subMenuElements.length === 0) {


### PR DESCRIPTION
* Use `scrollHeight` to reduce the likelihood of mobile rendering in particular having intermittent bugs
* Remove the repaint after 1s as that didn't seem to fix things
* Cheat a bit by setting a 60px minimum offset

Looking at https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight, it seems plausible that this property might be a little less sensitive to temporary aspects of the render like a scrollbar not existing yet at the moment body padding's first calculated.

> The scrollHeight value is equal to the minimum height the element would require in order to fit all the content in the viewport without using a vertical scrollbar.

Not certain at all but seems worth trying. This PR also adds logging for now, so we can get more of a sense of how much we are relying on the cheat/workaround of setting a 60px minimum offset.