### PR TITLE
DON-1095 – update Twitter/X branding

### DIFF
--- a/src/components/biggive-footer/biggive-footer.stories.tsx
+++ b/src/components/biggive-footer/biggive-footer.stories.tsx
@@ -29,7 +29,7 @@ const Template = () => `
         </ul>
         <div slot="social-icons">
         <biggive-social-icon service="Facebook" url="https://www.facebook.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
-        <biggive-social-icon service="Twitter" url="https://www.twitter.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
+        <biggive-social-icon service="Twitter" url="https://x.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
         <biggive-social-icon service="LinkedIn" url="https://www.linkedin.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
         <biggive-social-icon service="YouTube" url="https://www.youtube.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
         <biggive-social-icon service="Instagram" url="https://www.instagram.com" background-colour="tertiary" icon-colour="black"></biggive-social-icon>

--- a/src/components/biggive-footer/biggive-footer.tsx
+++ b/src/components/biggive-footer/biggive-footer.tsx
@@ -224,7 +224,7 @@ export class BiggiveFooter {
                   icon-colour="black"
                   wide={true}
                 ></biggive-social-icon>
-                <biggive-social-icon service="Twitter" url="https://twitter.com/BigGive" background-colour="tertiary" icon-colour="black" wide={true}></biggive-social-icon>
+                <biggive-social-icon service="Twitter" url="https://x.com/BigGive" background-colour="tertiary" icon-colour="black" wide={true}></biggive-social-icon>
                 <biggive-social-icon
                   service="LinkedIn"
                   url="https://uk.linkedin.com/company/big-give"

--- a/src/components/biggive-main-menu/biggive-main-menu.tsx
+++ b/src/components/biggive-main-menu/biggive-main-menu.tsx
@@ -159,7 +159,7 @@ export class BiggiveMainMenu {
         <div class="row row-top">
           <div class="social-icon-wrap">
             <biggive-social-icon service="Facebook" url="https://www.facebook.com/BigGive.org" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
-            <biggive-social-icon service="Twitter" url="https://twitter.com/BigGive" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
+            <biggive-social-icon service="Twitter" url="https://x.com/BigGive" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
             <biggive-social-icon service="LinkedIn" url="https://uk.linkedin.com/company/big-give" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
             <biggive-social-icon
               service="YouTube"
@@ -322,7 +322,7 @@ export class BiggiveMainMenu {
               </div>
               <div class="mobile-social-icon-wrap mobile-only">
                 <biggive-social-icon service="Facebook" url="https://www.facebook.com/BigGive.org" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
-                <biggive-social-icon service="Twitter" url="https://twitter.com/BigGive" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
+                <biggive-social-icon service="Twitter" url="https://x.com/BigGive" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
                 <biggive-social-icon service="LinkedIn" url="https://uk.linkedin.com/company/big-give" background-colour="tertiary" icon-colour="black"></biggive-social-icon>
                 <biggive-social-icon
                   service="YouTube"

--- a/src/components/biggive-main-menu/test/biggive-main-menu.spec.tsx
+++ b/src/components/biggive-main-menu/test/biggive-main-menu.spec.tsx
@@ -26,7 +26,7 @@ describe('biggive-main-menu', () => {
         <div class="row row-top">
           <div class="social-icon-wrap">
             <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Facebook" url="https://www.facebook.com/BigGive.org"></biggive-social-icon>
-            <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Twitter" url="https://twitter.com/BigGive"></biggive-social-icon>
+            <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Twitter" url="https://x.com/BigGive"></biggive-social-icon>
             <biggive-social-icon background-colour="tertiary" icon-colour="black" service="LinkedIn" url="https://uk.linkedin.com/company/big-give"></biggive-social-icon>
             <biggive-social-icon background-colour="tertiary" icon-colour="black" service="YouTube" url="https://www.youtube.com/channel/UC9_wH1aaTuZurJ-F9R8GDcA"></biggive-social-icon>
             <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Instagram" url="https://www.instagram.com/biggiveorg"></biggive-social-icon>
@@ -234,7 +234,7 @@ describe('biggive-main-menu', () => {
               </div>
               <div class="mobile-only mobile-social-icon-wrap">
                 <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Facebook" url="https://www.facebook.com/BigGive.org"></biggive-social-icon>
-                <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Twitter" url="https://twitter.com/BigGive"></biggive-social-icon>
+                <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Twitter" url="https://x.com/BigGive"></biggive-social-icon>
                 <biggive-social-icon background-colour="tertiary" icon-colour="black" service="LinkedIn" url="https://uk.linkedin.com/company/big-give"></biggive-social-icon>
                 <biggive-social-icon background-colour="tertiary" icon-colour="black" service="YouTube" url="https://www.youtube.com/channel/UC9_wH1aaTuZurJ-F9R8GDcA"></biggive-social-icon>
                 <biggive-social-icon background-colour="tertiary" icon-colour="black" service="Instagram" url="https://www.instagram.com/biggiveorg"></biggive-social-icon>

--- a/src/components/biggive-social-icon/test/biggive-social-icon.spec.tsx
+++ b/src/components/biggive-social-icon/test/biggive-social-icon.spec.tsx
@@ -5,14 +5,14 @@ describe('biggive-social-icon', () => {
   it('renders', async () => {
     const page = await newSpecPage({
       components: [BiggiveSocialIcon],
-      html: `<biggive-social-icon service="Twitter" url="https://www.twitter.com"></biggive-social-icon>`,
+      html: `<biggive-social-icon service="Twitter" url="https://x.com"></biggive-social-icon>`,
     });
     expect(page.root).toEqualHtml(`
-      <biggive-social-icon service="Twitter" url="https://www.twitter.com">
+      <biggive-social-icon service="Twitter" url="https://x.com">
         <div class="background-colour-primary social-icon-item">
-          <a aria-label="Big Give on Twitter" href="https://www.twitter.com" target="_blank" rel="noopener">
+          <a aria-label="Big Give on Twitter" href="https://x.com" target="_blank" rel="noopener">
             <svg class="fill-white" height="512" viewBox="0 0 512 512" width="512" xmlns="http://www.w3.org/2000/svg">
-              <path d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"></path>
+              <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"></path>
             </svg>
           </a>
         </div>

--- a/src/util/fontawesome-icons.ts
+++ b/src/util/fontawesome-icons.ts
@@ -1,4 +1,4 @@
-import { faAccessibleIcon, IconDefinition, faFacebookF, faTwitter, faYoutube, faInstagram, faLinkedinIn, faWhatsapp } from '@fortawesome/free-brands-svg-icons';
+import { faAccessibleIcon, IconDefinition, faFacebookF, faYoutube, faInstagram, faLinkedinIn, faWhatsapp, faXTwitter } from '@fortawesome/free-brands-svg-icons';
 import {
   faBaby,
   faBalanceScale,
@@ -93,7 +93,7 @@ export class FontAwesomeIconsService {
       },
       {
         name: 'Twitter',
-        icon: faTwitter,
+        icon: faXTwitter,
       },
       {
         name: 'Instagram',


### PR DESCRIPTION
Use new logo everywhere. Update our own socials to x.com versions.

Still use 'Twitter' in logo ARIA labels for screen readers etc. for now.