### PR TITLE
Build with Angular 19 and Stencil 4.26; require Angular 19.1+ as a peer

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -9,24 +9,24 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^18.2.0",
-    "@angular/common": "^18.2.0",
-    "@angular/compiler": "^18.2.0",
-    "@angular/core": "^18.2.0",
-    "@angular/forms": "^18.2.0",
-    "@angular/platform-browser": "^18.2.0",
-    "@angular/platform-browser-dynamic": "^18.2.0",
-    "@angular/router": "^18.2.0",
+    "@angular/animations": "^19.1.6",
+    "@angular/common": "^19.1.6",
+    "@angular/compiler": "^19.1.6",
+    "@angular/core": "^19.1.6",
+    "@angular/forms": "^19.1.6",
+    "@angular/platform-browser": "^19.1.6",
+    "@angular/platform-browser-dynamic": "^19.1.6",
+    "@angular/router": "^19.1.6",
     "@biggive/components": "*",
-    "@stencil/core": "4.23.*",
+    "@stencil/core": "4.26.*",
     "rxjs": "~7.5.0",
     "tslib": "^2.6.2",
-    "zone.js": "~0.14.4"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.2.0",
-    "@angular/cli": "^18.2.0",
-    "@angular/compiler-cli": "^18.2.0",
+    "@angular-devkit/build-angular": "^19.1.7",
+    "@angular/cli": "^19.1.7",
+    "@angular/compiler-cli": "^19.1.6",
     "@types/jasmine": "~4.0.0",
     "jasmine-core": "~4.2.0",
     "karma": "~6.4.0",
@@ -34,7 +34,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
-    "ng-packagr": "^18.2.0",
+    "ng-packagr": "^19.1.2",
     "typescript": "^5.5.4"
   }
 }

--- a/angular/projects/components/package.json
+++ b/angular/projects/components/package.json
@@ -4,8 +4,8 @@
   "_comment": "Version number below is automatically replaced during CircleCI build.",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": "^18.0.0||^19.0.0",
-    "@angular/core": "^18.0.0||^19.0.0",
+    "@angular/common": "^19.1.0",
+    "@angular/core": "^19.1.0",
     "@biggive/components": "*"
   },
   "dependencies": {

--- a/angular/projects/components/src/lib/components.module.ts
+++ b/angular/projects/components/src/lib/components.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { NgModule, provideAppInitializer } from '@angular/core';
 import { DIRECTIVES } from './stencil-generated';
 
 import { defineCustomElements } from '@biggive/components/loader';
@@ -9,11 +9,10 @@ import { defineCustomElements } from '@biggive/components/loader';
   declarations: [...DIRECTIVES],
   exports: [...DIRECTIVES],
   providers: [
-    {
-      provide: APP_INITIALIZER,
-      useFactory: () => defineCustomElements,
-      multi: true,
-    },
+    provideAppInitializer(() => {
+        const initializerFn = (() => defineCustomElements)();
+        return initializerFn();
+      }),
   ],
 })
 export class ComponentsModule { }

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -9,6 +9,7 @@
       ]
     },
     "outDir": "./dist/out-tsc",
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
@@ -17,7 +18,6 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION
Said yes to auto migrations for the `angular/` components project