### PR TITLE
Turn off Stencil auto update PRs that would use 4.26+, for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      - dependency-name: "@stencil/core"
+        versions: [">=4.26.0"]
       - dependency-name: storybook
         update-types: ["version-update:semver-major"]
       - dependency-name: storybook/addon-actions


### PR DESCRIPTION
Until https://github.com/stenciljs/core/issues/6206 fixed