### PR TITLE
COM-104: Use actually reasonable URLs in philco header/footer links

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1098,14 +1098,8 @@ export namespace Components {
         "videoUrl": string;
     }
     interface PhilcoFooter {
-        "blogUrlPrefix": string | undefined;
-        /**
-          * URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props
-         */
-        "donateUrlPrefix": string;
-        "experienceUrlPrefix": string | undefined;
         "headingLevel": 1 | 2 | 3 | 4 | 5 | 6;
-        "smallCharityWeekEnabled": boolean;
+        "philcoUrlPrefix": string;
     }
     interface PhilcoMainMenu {
         "closeMobileMenuFromOutside": () => Promise<void>;
@@ -2720,14 +2714,8 @@ declare namespace LocalJSX {
         "videoUrl"?: string;
     }
     interface PhilcoFooter {
-        "blogUrlPrefix"?: string | undefined;
-        /**
-          * URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props
-         */
-        "donateUrlPrefix"?: string;
-        "experienceUrlPrefix"?: string | undefined;
         "headingLevel"?: 1 | 2 | 3 | 4 | 5 | 6;
-        "smallCharityWeekEnabled"?: boolean;
+        "philcoUrlPrefix"?: string;
     }
     interface PhilcoMainMenu {
         "onLogoutClicked"?: (event: PhilcoMainMenuCustomEvent<void>) => void;

--- a/src/components/philco-footer/philco-footer.tsx
+++ b/src/components/philco-footer/philco-footer.tsx
@@ -29,7 +29,7 @@ export class PhilcoFooter {
         <div class="row row-top">
           <nav class="nav nav-primary" aria-labelledby="footer-primary-heading">
             <HeadingTag class="heading" id="footer-primary-heading">
-              <div slot="nav-primary-title">CONTACT</div>
+              <div slot="nav-primary-title">Contact</div>
             </HeadingTag>
             <ul slot="nav-primary">
               <li>PhilCo@biggive.org</li>
@@ -38,7 +38,7 @@ export class PhilcoFooter {
 
           <nav class="nav nav-secondary" aria-labelledby="footer-secondary-heading-heading">
             <HeadingTag class="heading" id="footer-secondary-heading">
-              <div slot="nav-secondary-title">PHILCO SITE</div>
+              <div slot="nav-secondary-title">Philco Site</div>
             </HeadingTag>
             <ul slot="nav-secondary">
               <li>
@@ -55,7 +55,7 @@ export class PhilcoFooter {
 
           <nav class="nav nav-tertiary" aria-labelledby="footer-tertiary-heading">
             <HeadingTag class="heading" id="footer-tertiary-heading">
-              <div slot="nav-tertiary-title">GUIDE</div>
+              <div slot="nav-tertiary-title">Guide</div>
             </HeadingTag>
             <ul slot="nav-tertiary">
               <li>

--- a/src/components/philco-footer/philco-footer.tsx
+++ b/src/components/philco-footer/philco-footer.tsx
@@ -11,14 +11,7 @@ export class PhilcoFooter {
 
   @Prop() headingLevel: 1 | 2 | 3 | 4 | 5 | 6 = 5;
 
-  /**
-   * URL prefixes vary by environment, and components library is not best placed to know what they are, so we
-   * take them as props
-   */
-  @Prop() donateUrlPrefix: string = 'http://';
-  @Prop() blogUrlPrefix: string | undefined = 'http://';
-  @Prop() experienceUrlPrefix: string | undefined = 'http://';
-  @Prop() smallCharityWeekEnabled = false;
+  @Prop() philcoUrlPrefix: string = 'https://philco.org.uk/';
 
   private year: string = new Date().getFullYear().toString();
 
@@ -49,13 +42,13 @@ export class PhilcoFooter {
             </HeadingTag>
             <ul slot="nav-secondary">
               <li>
-                <a href={makeURL('Blog', this.blogUrlPrefix, 'case-studies')}>Home</a>
+                <a href={makeURL('Philco', this.philcoUrlPrefix, '/')}>Home</a>
               </li>
               <li>
-                <a href={makeURL('Blog', this.blogUrlPrefix, 'blog')}>Why become a Philco</a>
+                <a href={makeURL('Philco', this.philcoUrlPrefix, 'why-become-a-philco')}>Why become a Philco</a>
               </li>
               <li>
-                <a href={makeURL('Blog', this.blogUrlPrefix, 'reports-insights')}>Sign Up</a>
+                <a href={makeURL('Philco', this.philcoUrlPrefix, 'sign-up')}>Sign Up</a>
               </li>
             </ul>
           </nav>
@@ -66,7 +59,7 @@ export class PhilcoFooter {
             </HeadingTag>
             <ul slot="nav-tertiary">
               <li>
-                <a href={makeURL('Blog', this.blogUrlPrefix, 'support')}>Download the guide</a>
+                <a href={makeURL('Philco', this.philcoUrlPrefix, 'download-the-guide')}>Download the guide</a>
               </li>
             </ul>
           </nav>
@@ -77,16 +70,13 @@ export class PhilcoFooter {
             <nav class="nav nav-postscript" aria-label="Legal">
               <ul slot="nav-postscript">
                 <li>
-                  <a href={makeURL('Blog', this.blogUrlPrefix, 'terms-and-conditions')}>Terms and Conditions</a>
+                  <a href={makeURL('Philco', this.philcoUrlPrefix, 'terms-and-conditions')}>Terms and Conditions</a>
                 </li>
                 <li>
-                  <a href={makeURL('Blog', this.blogUrlPrefix, 'privacy')}>Privacy Statement</a>
+                  <a href={makeURL('Philco', this.philcoUrlPrefix, 'privacy')}>Privacy Statement</a>
                 </li>
                 <li>
-                  <a href={makeURL('Blog', this.blogUrlPrefix, 'privacy#cookies')}>Cookies Statement</a>
-                </li>
-                <li>
-                  <a href={makeURL('Donate', this.donateUrlPrefix, 'cookie-preferences')}>Cookies Preference Centre</a>
+                  <a href={makeURL('Philco', this.philcoUrlPrefix, 'privacy#cookies')}>Cookies Statement</a>
                 </li>
               </ul>
             </nav>

--- a/src/components/philco-footer/readme.md
+++ b/src/components/philco-footer/readme.md
@@ -7,13 +7,10 @@
 
 ## Properties
 
-| Property                  | Attribute                    | Description                                                                                                                 | Type                         | Default     |
-| ------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------- |
-| `blogUrlPrefix`           | `blog-url-prefix`            |                                                                                                                             | `string \| undefined`        | `'http://'` |
-| `donateUrlPrefix`         | `donate-url-prefix`          | URL prefixes vary by environment, and components library is not best placed to know what they are, so we take them as props | `string`                     | `'http://'` |
-| `experienceUrlPrefix`     | `experience-url-prefix`      |                                                                                                                             | `string \| undefined`        | `'http://'` |
-| `headingLevel`            | `heading-level`              |                                                                                                                             | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | `5`         |
-| `smallCharityWeekEnabled` | `small-charity-week-enabled` |                                                                                                                             | `boolean`                    | `false`     |
+| Property          | Attribute           | Description | Type                         | Default                    |
+| ----------------- | ------------------- | ----------- | ---------------------------- | -------------------------- |
+| `headingLevel`    | `heading-level`     |             | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | `5`                        |
+| `philcoUrlPrefix` | `philco-url-prefix` |             | `string`                     | `'https://philco.org.uk/'` |
 
 
 ----------------------------------------------

--- a/src/util/helper-methods.ts
+++ b/src/util/helper-methods.ts
@@ -1,4 +1,5 @@
-export const makeURL = (urlType: string, urlPrefix: string | undefined, relativeUrl: string) => {
+type urlType = 'Blog' | 'Donate' | 'Philco' | 'Experience';
+export const makeURL = (urlType: urlType, urlPrefix: string | undefined, relativeUrl: string) => {
   if (urlPrefix === undefined || urlPrefix.length === 0 || !urlPrefix.startsWith('http')) {
     const prefixType = typeof urlPrefix;
     throw new Error(`${urlType} URL prefix must be set and start with http: bad prefix (${prefixType}) '${urlPrefix}'`);


### PR DESCRIPTION
Previously URLs were remnants of copy & paste from BG components, these are now my best guesses of what we may actually want the URls to be.

Also deleted the cookie preference centre link as I don't expect we will have such for Philco