### PR TITLE
Set an accessible label for selects that rely on a placeholder value

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -514,7 +514,7 @@ export namespace Components {
          */
         "options": string | Array<{ label: string; value: string }>;
         /**
-          * Placeholder
+          * Placeholder. If there is no `prompt`, this should be a suitable ARIA label.
          */
         "placeholder": string | undefined;
         /**
@@ -2109,7 +2109,7 @@ declare namespace LocalJSX {
          */
         "options": string | Array<{ label: string; value: string }>;
         /**
-          * Placeholder
+          * Placeholder. If there is no `prompt`, this should be a suitable ARIA label.
          */
         "placeholder"?: string | undefined;
         /**

--- a/src/components/biggive-form-field-select/biggive-form-field-select.tsx
+++ b/src/components/biggive-form-field-select/biggive-form-field-select.tsx
@@ -42,8 +42,9 @@ export class BiggiveFormFieldSelect {
    * Space below component
    */
   @Prop() spaceBelow: number = 0;
+
   /**
-   * Placeholder
+   * Placeholder. If there is no `prompt`, this should be a suitable ARIA label.
    */
   @Prop() placeholder: string | undefined;
 
@@ -76,7 +77,7 @@ export class BiggiveFormFieldSelect {
             }
           >
             <div class="sleeve">
-              <select class={greyIfRequired} onChange={this.doOptionSelectCompletedHandler}>
+              <select class={greyIfRequired} onChange={this.doOptionSelectCompletedHandler} aria-label={this.prompt === null ? this.placeholder : this.prompt}>
                 {options.map(option => (
                   <option selected={this.selectedValue === option.value} value={option.value}>
                     {option.label}

--- a/src/components/biggive-form-field-select/readme.md
+++ b/src/components/biggive-form-field-select/readme.md
@@ -11,7 +11,7 @@
 | ---------------------- | ------------------------ | ------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------ |
 | `backgroundColour`     | `background-colour`      | Must match background of containing element, or unintended shape will appear.         | `"grey" \| "white"`                             | `undefined`  |
 | `options` _(required)_ | `options`                | JSON array of label+value objects, or takes a stringified equiavalent (for Storybook) | `string \| { label: string; value: string; }[]` | `undefined`  |
-| `placeholder`          | `placeholder`            | Placeholder                                                                           | `string \| undefined`                           | `undefined`  |
+| `placeholder`          | `placeholder`            | Placeholder. If there is no `prompt`, this should be a suitable ARIA label.           | `string \| undefined`                           | `undefined`  |
 | `prompt` _(required)_  | `prompt`                 | Displayed as 'eyebrow' label over the top border of the box.                          | `null \| string`                                | `undefined`  |
 | `selectStyle`          | `select-style`           |                                                                                       | `"bordered" \| "underlined"`                    | `'bordered'` |
 | `selectedLabel`        | `selected-label`         |                                                                                       | `null \| string`                                | `undefined`  |

--- a/src/components/biggive-form-field-select/test/biggive-form-field-select.spec.tsx
+++ b/src/components/biggive-form-field-select/test/biggive-form-field-select.spec.tsx
@@ -18,7 +18,7 @@ describe('biggive-form-field-select', () => {
               <div class="prompt">What would you like?</div>
               <div class="dropdown select-style-bordered space-below-0">
                 <div class="sleeve">
-                  <select>
+                  <select aria-label="What would you like?">
                     <option value="optionOne">
                       Option one
                     </option>


### PR DESCRIPTION
e.g. campaign sorting