### PR TITLE
COM-83: Add explicit label for select element

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -521,6 +521,10 @@ export namespace Components {
           * Displayed as 'eyebrow' label over the top border of the box.
          */
         "prompt": string | null;
+        /**
+          * ID for the select element, used by a label. If not passed then a random id will be generated.
+         */
+        "selectElementId": string | undefined;
         "selectStyle": 'bordered' | 'underlined';
         "selectedLabel": string | null;
         "selectedOptionColour": 'inherit' | 'blue';
@@ -2116,6 +2120,10 @@ declare namespace LocalJSX {
           * Displayed as 'eyebrow' label over the top border of the box.
          */
         "prompt": string | null;
+        /**
+          * ID for the select element, used by a label. If not passed then a random id will be generated.
+         */
+        "selectElementId"?: string | undefined;
         "selectStyle"?: 'bordered' | 'underlined';
         "selectedLabel"?: string | null;
         "selectedOptionColour"?: 'inherit' | 'blue';

--- a/src/components/biggive-form-field-select/biggive-form-field-select.tsx
+++ b/src/components/biggive-form-field-select/biggive-form-field-select.tsx
@@ -31,6 +31,11 @@ export class BiggiveFormFieldSelect {
 
   @Prop() selectedOptionColour: 'inherit' | 'blue' = 'blue';
 
+  /**
+   * ID for the select element, used by a label. If not passed then a random id will be generated.
+   */
+  @Prop() selectElementId: string | undefined;
+
   private doOptionSelectCompletedHandler = (event: any) => {
     const value = event.target.value;
     this.selectedValue = value;
@@ -61,33 +66,35 @@ export class BiggiveFormFieldSelect {
       console.error('options undefined');
       options = [];
     }
+    // Give the select a random id so we can reference it from a label
+    const selectId = this.selectElementId || 'select-' + this.getRandomInt().toString();
 
     return (
       <div class="selectWrapper">
-        <label class={greyIfRequired}>
+        <label class={greyIfRequired} htmlFor={selectId}>
           <div class={'prompt' + greyIfRequired}>{this.prompt}</div>
-          <div
-            class={
-              'dropdown space-below-' +
-              this.spaceBelow +
-              ' select-style-' +
-              this.selectStyle +
-              (this.prompt === null ? '  noprompt' : '') +
-              (this.selectedOptionColour === 'inherit' ? ' inherit-colour' : '')
-            }
-          >
-            <div class="sleeve">
-              <select class={greyIfRequired} onChange={this.doOptionSelectCompletedHandler} aria-label={this.prompt === null ? this.placeholder : this.prompt}>
-                {options.map(option => (
-                  <option selected={this.selectedValue === option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              <div class="arrow"></div>
-            </div>
-          </div>
         </label>
+        <div
+          class={
+            'dropdown space-below-' +
+            this.spaceBelow +
+            ' select-style-' +
+            this.selectStyle +
+            (this.prompt === null ? '  noprompt' : '') +
+            (this.selectedOptionColour === 'inherit' ? ' inherit-colour' : '')
+          }
+        >
+          <div class="sleeve">
+            <select id={selectId} class={greyIfRequired} onChange={this.doOptionSelectCompletedHandler} aria-label={this.prompt === null ? this.placeholder : this.prompt}>
+              {options.map(option => (
+                <option selected={this.selectedValue === option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <div class="arrow"></div>
+          </div>
+        </div>
       </div>
     );
   }
@@ -109,5 +116,11 @@ export class BiggiveFormFieldSelect {
     }
 
     return Object.entries(options).map(entry => ({ value: entry[0], label: entry[1] }));
+  }
+
+  private getRandomInt(): number {
+    const min = 1_000_000;
+    const max = 9_999_999;
+    return Math.floor(Math.random() * (max - min) + min);
   }
 }

--- a/src/components/biggive-form-field-select/readme.md
+++ b/src/components/biggive-form-field-select/readme.md
@@ -7,18 +7,19 @@
 
 ## Properties
 
-| Property               | Attribute                | Description                                                                           | Type                                            | Default      |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------ |
-| `backgroundColour`     | `background-colour`      | Must match background of containing element, or unintended shape will appear.         | `"grey" \| "white"`                             | `undefined`  |
-| `options` _(required)_ | `options`                | JSON array of label+value objects, or takes a stringified equiavalent (for Storybook) | `string \| { label: string; value: string; }[]` | `undefined`  |
-| `placeholder`          | `placeholder`            | Placeholder. If there is no `prompt`, this should be a suitable ARIA label.           | `string \| undefined`                           | `undefined`  |
-| `prompt` _(required)_  | `prompt`                 | Displayed as 'eyebrow' label over the top border of the box.                          | `null \| string`                                | `undefined`  |
-| `selectStyle`          | `select-style`           |                                                                                       | `"bordered" \| "underlined"`                    | `'bordered'` |
-| `selectedLabel`        | `selected-label`         |                                                                                       | `null \| string`                                | `undefined`  |
-| `selectedOptionColour` | `selected-option-colour` |                                                                                       | `"blue" \| "inherit"`                           | `'blue'`     |
-| `selectedValue`        | `selected-value`         |                                                                                       | `null \| string`                                | `undefined`  |
-| `selectionChanged`     | --                       |                                                                                       | `(value: string) => void`                       | `undefined`  |
-| `spaceBelow`           | `space-below`            | Space below component                                                                 | `number`                                        | `0`          |
+| Property               | Attribute                | Description                                                                                   | Type                                            | Default      |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------ |
+| `backgroundColour`     | `background-colour`      | Must match background of containing element, or unintended shape will appear.                 | `"grey" \| "white"`                             | `undefined`  |
+| `options` _(required)_ | `options`                | JSON array of label+value objects, or takes a stringified equiavalent (for Storybook)         | `string \| { label: string; value: string; }[]` | `undefined`  |
+| `placeholder`          | `placeholder`            | Placeholder. If there is no `prompt`, this should be a suitable ARIA label.                   | `string \| undefined`                           | `undefined`  |
+| `prompt` _(required)_  | `prompt`                 | Displayed as 'eyebrow' label over the top border of the box.                                  | `null \| string`                                | `undefined`  |
+| `selectElementId`      | `select-element-id`      | ID for the select element, used by a label. If not passed then a random id will be generated. | `string \| undefined`                           | `undefined`  |
+| `selectStyle`          | `select-style`           |                                                                                               | `"bordered" \| "underlined"`                    | `'bordered'` |
+| `selectedLabel`        | `selected-label`         |                                                                                               | `null \| string`                                | `undefined`  |
+| `selectedOptionColour` | `selected-option-colour` |                                                                                               | `"blue" \| "inherit"`                           | `'blue'`     |
+| `selectedValue`        | `selected-value`         |                                                                                               | `null \| string`                                | `undefined`  |
+| `selectionChanged`     | --                       |                                                                                               | `(value: string) => void`                       | `undefined`  |
+| `spaceBelow`           | `space-below`            | Space below component                                                                         | `number`                                        | `0`          |
 
 
 ## Dependencies

--- a/src/components/biggive-form-field-select/test/biggive-form-field-select.spec.tsx
+++ b/src/components/biggive-form-field-select/test/biggive-form-field-select.spec.tsx
@@ -7,18 +7,20 @@ describe('biggive-form-field-select', () => {
       components: [BiggiveFormFieldSelect],
       html: `<biggive-form-field-select
                 prompt="What would you like?"
+                select-element-id="some-id"
                 options='[{"value": "optionOne", "label": "Option one"},{"value": "optionTwo", "label": "Option two"}]'
               ></biggive-form-field-select>`,
     });
     expect(page.root).toEqualHtml(`
-      <biggive-form-field-select options="[{&quot;value&quot;: &quot;optionOne&quot;, &quot;label&quot;: &quot;Option one&quot;},{&quot;value&quot;: &quot;optionTwo&quot;, &quot;label&quot;: &quot;Option two&quot;}]" prompt="What would you like?">
+      <biggive-form-field-select options="[{&quot;value&quot;: &quot;optionOne&quot;, &quot;label&quot;: &quot;Option one&quot;},{&quot;value&quot;: &quot;optionTwo&quot;, &quot;label&quot;: &quot;Option two&quot;}]" prompt="What would you like?" select-element-id="some-id">
         <mock:shadow-root>
           <div class="selectWrapper">
-            <label>
+            <label htmlfor="some-id">
               <div class="prompt">What would you like?</div>
+              </label>
               <div class="dropdown select-style-bordered space-below-0">
                 <div class="sleeve">
-                  <select aria-label="What would you like?">
+                  <select id="some-id" aria-label="What would you like?">
                     <option value="optionOne">
                       Option one
                     </option>
@@ -29,7 +31,6 @@ describe('biggive-form-field-select', () => {
                   <div class="arrow"></div>
                 </div>
               </div>
-            </label>
           </div>
         </mock:shadow-root>
       </biggive-form-field-select>


### PR DESCRIPTION
Story book is still not working I'm afraid but this should be easy to test at http://localhost:3939/pages/biggive.html 

Clicking the target icon for me in firefox opens the select node within the inspector

![image](https://github.com/user-attachments/assets/50db57f3-adc0-4828-9b59-08b127414c7a)
