### PR TITLE
Adjust link to philco guide

### DIFF
--- a/src/components/philco-footer/philco-footer.tsx
+++ b/src/components/philco-footer/philco-footer.tsx
@@ -63,7 +63,7 @@ export class PhilcoFooter {
             </HeadingTag>
             <ul slot="nav-tertiary">
               <li>
-                <a href={makeURL('Philco', this.philcoUrlPrefix, 'download-the-guide')}>Download the guide</a>
+                <a href="https://drive.google.com/file/d/1D1GnstpMKnnES1aYj05EVE9_lQtLZLwj/view">Download the guide</a>
               </li>
             </ul>
           </nav>


### PR DESCRIPTION
See comments on ticket

Linked works on my local at http://localhost:3939/pages/philco.html

![image](https://github.com/user-attachments/assets/3acacd65-0c7a-4bdd-890a-fc92cc073dc4)
