### PR TITLE
WPD-192: Fix ER colours

### DIFF
--- a/src/globals/variables.scss
+++ b/src/globals/variables.scss
@@ -58,9 +58,9 @@ $brandColours: (
     "brand-cc-red": $colour-brand-cc-red,
     "brand-wgmf-purple": $colour-brand-wgmf-purple,
     "brand-gmf-green": $colour-brand-gmf-green, // deprecated name
-    "colour-brand-er-green": $colour-brand-er-green,
-    "colour-brand-er-dark-blue": $colour-brand-er-dark-blue,
-    "colour-brand-er-teal": $colour-brand-er-teal,
+    "brand-er-green": $colour-brand-er-green,
+    "brand-er-dark-blue": $colour-brand-er-dark-blue,
+    "brand-er-teal": $colour-brand-er-teal,
     "brand-emf-yellow": $colour-brand-emf-yellow,
     "brand-c4c-orange": $colour-brand-c4c-orange,
     "brand-afa-pink": $colour-brand-afa-pink,


### PR DESCRIPTION
The names of these were wrong, meaning they could be selected but didn't actually work as backgrounds in WP.