### PR TITLE
WPD-192: Fix missing er-dark-green colour

### DIFF
--- a/src/globals/variables.scss
+++ b/src/globals/variables.scss
@@ -59,6 +59,7 @@ $brandColours: (
     "brand-wgmf-purple": $colour-brand-wgmf-purple,
     "brand-gmf-green": $colour-brand-gmf-green, // deprecated name
     "brand-er-green": $colour-brand-er-green,
+    "brand-er-dark-green": $colour-brand-er-dark-green,
     "brand-er-dark-blue": $colour-brand-er-dark-blue,
     "brand-er-teal": $colour-brand-er-teal,
     "brand-emf-yellow": $colour-brand-emf-yellow,


### PR DESCRIPTION
I also some code to test html to see all the ER colours so I could see that this fixes the dark green by didn't commit that

![image](https://github.com/user-attachments/assets/188666a9-97b1-4387-8aa3-cafdc7d88b2c)
