### PR TITLE
WPD-195 – PhilCo header & footer fixes

### DIFF
--- a/src/components/biggive-basic-card/biggive-basic-card.scss
+++ b/src/components/biggive-basic-card/biggive-basic-card.scss
@@ -17,6 +17,7 @@
   padding: $spacer-4;
   &.philco {
     @include philco-body-font();
+    line-height: $philco-standard-body-line-height;
     border-bottom: 12px;
     border-bottom-left-radius: 12px;
     border-bottom-right-radius: 12px;

--- a/src/components/biggive-quote/biggive-quote.scss
+++ b/src/components/biggive-quote/biggive-quote.scss
@@ -13,6 +13,7 @@
   background-color: white;
   &.philco {
     @include philco-body-font();
+    line-height: $philco-standard-body-line-height;
     background-color: transparent;
     .image-wrap {
       overflow: hidden;

--- a/src/components/philco-footer/philco-footer.scss
+++ b/src/components/philco-footer/philco-footer.scss
@@ -4,6 +4,7 @@
 
 .footer {
   @include philco-body-font();
+  line-height: $philco-standard-body-line-height;
   color: $colour-philco-gray-90;
 }
 

--- a/src/components/philco-footer/philco-footer.scss
+++ b/src/components/philco-footer/philco-footer.scss
@@ -46,24 +46,12 @@ nav ul li a {
 }
 
 .row-top {
-  // @todo-COM-104: Replace background image below with a black-on-white PhilCo logo
-  //background-image: url(/assets/images/biggive-triangle-green.svg);
-  background-repeat: no-repeat;
-  background-size: auto 75px;
-  background-position: $spacer-6 30px;
   background-color: $colour-philco-white;
-  padding: 0 $spacer-6 $spacer-6 $spacer-6;
+  // $icon-size-large happens to be approx. the UA-default top heading margin that we relied upon last.
+  padding: $icon-size-large $spacer-6 $spacer-6 $spacer-6;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-
-  .button-wrap {
-    margin-top: $spacer-6;
-    width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-  }
 }
 
 footer .row-bottom {
@@ -133,33 +121,16 @@ footer .row-bottom {
 
 @media screen and (max-width: $screen-tablet-max) {
   .row-logo {
-    padding-left: $spacer-3 $spacer-3 0 $spacer-3;
+    padding: $spacer-5 $spacer-3 $spacer-3 $spacer-3;
   }
-  .row-top {
-    padding: 0 $spacer-3 $spacer-3 $spacer-3;
-  }
-}
 
-@media screen and (max-width: $screen-tablet-max) {
+  .row-top {
+    padding: $spacer-4 $spacer-3 $spacer-3 $spacer-3;
+  }
+
   nav {
     width: 100%;
     margin-right: 0;
     margin-bottom: $spacer-4;
-  }
-
-  .row-logo {
-    padding-top: 80px;
-    padding-left: 15px;
-  }
-
-  .row-top {
-    background-size: auto 50px;
-    padding-top: 0;
-    padding-left: 15px;
-    background-position: 15px 30px;
-
-    .button-wrap * {
-      width: 100% !important;
-    }
   }
 }

--- a/src/globals/mixins.scss
+++ b/src/globals/mixins.scss
@@ -10,13 +10,12 @@
 
 @mixin philco-subhead-font() {
   font-family: 'Bitter', serif;
-  line-height: 1.2rem;
+  line-height: $philco-standard-body-line-height;
 }
 
 @mixin philco-body-font() {
   font-family: 'Bitter', serif;
   font-size: 16px;
-  line-height: 1.2rem;
 }
 
 @mixin philco-heading-font() {

--- a/src/globals/philco-variables.scss
+++ b/src/globals/philco-variables.scss
@@ -7,3 +7,4 @@ $colour-philco-error-coral: #F54242;
 $colour-philco-gray-30: #BBBBBB;
 $colour-philco-gray-20: #F6F6F6;
 
+$philco-standard-body-line-height: 1.2rem;


### PR DESCRIPTION
My aim with the footer changes is to get things almost exactly as Production is again on desktop.

I slightly reduced vertical space in a couple of places on mobile where I thought it was a bit excessive, so that it's now like this in Firefox:

<img width="466" alt="Screenshot 2025-05-23 at 12 06 11" src="https://github.com/user-attachments/assets/e5674c09-e67a-4469-a1f0-831d984da486" />
