### PR TITLE
DON-1138: Add vertical spacing between filter buttons on narrow screens

### DIFF
--- a/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.scss
+++ b/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.scss
@@ -55,9 +55,10 @@
 }
 .selected-filter-wrap {
   display: flex;
-  margin-bottom: 30px;
+  margin-bottom: 23px;
   padding: 0;
   .button {
+    margin-bottom: 7px;
     display: inline-block;
     cursor: pointer;
     border-radius: 20px;


### PR DESCRIPTION
We only have up to three buttons at a time so on wide screens they never stack vertically.

Before:

![image](https://github.com/user-attachments/assets/5fbc1705-daf3-4ebf-8fa1-dd9b322df482)

![image](https://github.com/user-attachments/assets/5d87fa9e-7522-4ea8-85bb-b758d30c4b07)

![image](https://github.com/user-attachments/assets/299db3a9-1aa1-4988-81cc-5380a205123c)

![image](https://github.com/user-attachments/assets/db0043df-d203-4718-bfe5-2c8fc8ca92d6)


After:

![image](https://github.com/user-attachments/assets/17960f70-d971-49ee-ae3e-55738881ca5b)

![image](https://github.com/user-attachments/assets/7029351e-473d-4879-b26a-7041315bb191)

![image](https://github.com/user-attachments/assets/6ff7a415-2ddd-47d6-9d30-1d110e1e18a6)

![image](https://github.com/user-attachments/assets/27b5e69e-0b75-44dc-8b78-f72f0741029c)

