### PR TITLE
COM-106 – Fix `.sub-sub-menu` position on medium viewports

### DIFF
--- a/src/components/biggive-main-menu/biggive-main-menu.scss
+++ b/src/components/biggive-main-menu/biggive-main-menu.scss
@@ -188,7 +188,9 @@ nav {
               .sub-sub-menu {
                 position: absolute;
                 top: 0;
-                left: 100%;
+                // On tablet & small desktop there's often not enough room for an extra menu to the right,
+                // so left is safest.
+                right: 100%;
                 border-radius: 0 4px 4px 4px;
                 z-index: 1;
                 display: none;


### PR DESCRIPTION
<img width="1032" height="588" alt="Screenshot 2025-07-23 at 09 20 01" src="https://github.com/user-attachments/assets/a863b87b-3621-4f3d-be72-e4987e8ccdab" />

Note that the logic activating the mobile view of the same menu is based on `@media (hover: hover)` – so there is a pre-existing issue that using a tiny viewport on a desktop device gives an unusable 2nd level menu. (I think with this change it becomes a bit more obviously broken but both are bad.) If you simulate mobile including pointer events then you get a working mobile menu, so I think this is probably OK to ignore for now.