### PR TITLE
DON-1107: Big Give Campaign Card: Reserve space for progress bar to k…

### DIFF
--- a/src/components/biggive-campaign-card/biggive-campaign-card.tsx
+++ b/src/components/biggive-campaign-card/biggive-campaign-card.tsx
@@ -157,7 +157,13 @@ export class BiggiveCampaignCard {
                 )}
               </div>
             )}
-            {this.isEmpty(this.progressBarCounter) ? null : (
+            {this.isEmpty(this.progressBarCounter) ? (
+              // We don't have a progress bar to show in this case, so the following is just functioning as a spacer to
+              // keep layout consistent. Counter must be non-null to make bar display.
+              <div class="progress-bar-wrap" style={{ visibility: 'hidden' }}>
+                <biggive-progress-bar counter={0} colour-scheme="primary"></biggive-progress-bar>
+              </div>
+            ) : (
               <div class="progress-bar-wrap">
                 <biggive-progress-bar counter={this.progressBarCounter} colour-scheme="primary"></biggive-progress-bar>
               </div>

--- a/src/components/biggive-campaign-card/test/biggive-campaign-card.spec.tsx
+++ b/src/components/biggive-campaign-card/test/biggive-campaign-card.spec.tsx
@@ -91,6 +91,9 @@ describe('biggive-campaign-card', () => {
                  By
                </div>
              </div>
+             <div class="progress-bar-wrap" style="visibility: hidden;">
+              <biggive-progress-bar colour-scheme="primary" counter="0"></biggive-progress-bar>
+             </div>
            </div>
            <div class="button-wrap">
              <biggive-button colour-scheme="primary" full-width="true" label="Donate now"></biggive-button>


### PR DESCRIPTION
…eep layout consisent even when no progress bar number exists

**Before**:

<img width="1204" height="1001" alt="image" src="https://github.com/user-attachments/assets/73aff3ce-2aaa-4b9a-9d88-d4c6319f4220" />

**After**:

<img width="1204" height="1001" alt="image" src="https://github.com/user-attachments/assets/79d4e7fe-db14-4efb-86fb-217170a2e6b9" />
