### PR TITLE
COM-109: Fix regression where progress bar shows up when it should be…

### DIFF
--- a/src/components/biggive-progress-bar/biggive-progress-bar.tsx
+++ b/src/components/biggive-progress-bar/biggive-progress-bar.tsx
@@ -21,7 +21,9 @@ export class BiggiveProgressBar {
   @Prop() counter?: number | null = null;
 
   render() {
-    const visibility = typeof this.counter === 'number' ? 'visible' : 'hidden';
+    // important to use 'inherit' below rather than visible as the parent element may be hidden, in which case
+    // this should not show up.
+    const visibility = typeof this.counter === 'number' ? 'inherit' : 'hidden';
 
     return (
       <div style={{ visibility: visibility }} class={'progress-bar progress-bar-' + this.colourScheme + ' space-below-' + this.spaceBelow}>

--- a/src/components/biggive-progress-bar/test/biggive-progress-bar.spec.tsx
+++ b/src/components/biggive-progress-bar/test/biggive-progress-bar.spec.tsx
@@ -10,7 +10,7 @@ describe('biggive-progress-bar', () => {
     expect(page.root).toEqualHtml(`
       <biggive-progress-bar colour-scheme="primary" counter="100">
         <mock:shadow-root>
-          <div class="progress-bar progress-bar-primary space-below-0" style="visibility: visible;">
+          <div class="progress-bar progress-bar-primary space-below-0" style="visibility: inherit;">
             <div class="slider">
               <div class="progress" style="width: 100%;"></div>
             </div>


### PR DESCRIPTION
… hidden (for shared funds campaigns)

Before

<img width="1345" height="915" alt="image" src="https://github.com/user-attachments/assets/fd0ab4ee-47cd-4702-9ff4-7ef90c8b9dad" />


After:

<img width="1345" height="915" alt="image" src="https://github.com/user-attachments/assets/3f0ea30a-2be1-42c0-8a64-e7d447d67fd3" />
