### PR TITLE
DON-1205: Fix charities near me button disabled at wrong time

### DIFF
--- a/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
+++ b/src/components/biggive-campaign-card-filter-grid/biggive-campaign-card-filter-grid.tsx
@@ -360,7 +360,7 @@ export class BiggiveCampaignCardFilterGrid {
                 colourScheme="primary"
                 onDoButtonClick={this.handleNearMeButtonPressed}
                 label={this.fetchingLocation ? 'Fetching location...' : 'Charities near me'}
-                disabled={!this.fetchingLocation}
+                disabled={this.fetchingLocation}
                 fullWidth={true}
                 space-below="0"
               ></biggive-button>


### PR DESCRIPTION
Would have found this error sooner if we had styling that made it clear when the button was disabled, instead of it looking the same and just not doing anything. Maybe worth adding that in as part of other work or with a dedicated ticket.